### PR TITLE
feat: Display running duration for jobs

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -82,6 +82,7 @@ declare global {
   const useJobsStore: typeof import('./src/stores/jobs.store')['useJobsStore']
   const useLink: typeof import('vue-router')['useLink']
   const useModel: typeof import('vue')['useModel']
+  const formatDuration: typeof import('./src/composables/useFormatDuration')['formatDuration']
   const useRoute: typeof import('vue-router')['useRoute']
   const useRouter: typeof import('vue-router')['useRouter']
   const useSlots: typeof import('vue')['useSlots']
@@ -105,6 +106,9 @@ declare global {
   // @ts-ignore
   export type { Job, JobRequest } from './src/types/jobs'
   import('./src/types/jobs')
+  // @ts-ignore
+  export type { FormattedDuration } from './src/composables/useFormatDuration'
+  import('./src/composables/useFormatDuration')
 }
 
 // for vue template auto import

--- a/components.d.ts
+++ b/components.d.ts
@@ -17,6 +17,7 @@ declare module 'vue' {
     DataTable: typeof import('primevue/datatable')['default']
     Footer: typeof import('./src/components/Footer.vue')['default']
     Header: typeof import('./src/components/Header.vue')['default']
+    JobStatusTag: typeof import('./src/components/JobStatusTag.vue')['default']
     Message: typeof import('primevue/message')['default']
     Tag: typeof import('primevue/tag')['default']
     Toolbar: typeof import('primevue/toolbar')['default']

--- a/src/components/BotsDataTable.vue
+++ b/src/components/BotsDataTable.vue
@@ -8,22 +8,6 @@ const props = defineProps<Props>()
 const botsStore = useBotsStore()
 const authStore = useAuthStore()
 
-const formatDuration = (startedAt: Date | undefined): string => {
-  if (!startedAt) return ''
-
-  // Calculate duration based on current time at the moment of rendering
-  const diffMs = new Date().getTime() - startedAt.getTime()
-  if (diffMs < 0) return '' // Should not happen if clock is synced
-
-  const totalSeconds = Math.floor(diffMs / 1000)
-  const hours = Math.floor(totalSeconds / 3600)
-  const minutes = Math.floor((totalSeconds % 3600) / 60)
-  const seconds = totalSeconds % 60
-
-  const pad = (num: number) => num.toString().padStart(2, '0')
-
-  return `for ${pad(hours)}:${pad(minutes)}<span class="text-xs">:${pad(seconds)}</span>`
-}
 </script>
 
 <template>
@@ -43,19 +27,7 @@ const formatDuration = (startedAt: Date | undefined): string => {
 
     <Column header="Status">
       <template #body="{ data }">
-        <Tag :severity="data.status.severity">
-          <template #default>
-            <div class="flex items-center">
-              <span>{{ data.status.text }}</span>
-              <span
-                v-if="data.status.isRunning && data.status.startedAt"
-                class="ml-1"
-                v-html="formatDuration(data.status.startedAt)"
-              >
-              </span>
-            </div>
-          </template>
-        </Tag>
+        <JobStatusTag :status="data.status" />
       </template>
     </Column>
 

--- a/src/components/BotsDataTable.vue
+++ b/src/components/BotsDataTable.vue
@@ -7,6 +7,23 @@ interface Props {
 const props = defineProps<Props>()
 const botsStore = useBotsStore()
 const authStore = useAuthStore()
+
+const formatDuration = (startedAt: Date | undefined): string => {
+  if (!startedAt) return ''
+
+  // Calculate duration based on current time at the moment of rendering
+  const diffMs = new Date().getTime() - startedAt.getTime()
+  if (diffMs < 0) return '' // Should not happen if clock is synced
+
+  const totalSeconds = Math.floor(diffMs / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  const pad = (num: number) => num.toString().padStart(2, '0')
+
+  return `for ${pad(hours)}:${pad(minutes)}<span class="text-xs">:${pad(seconds)}</span>`
+}
 </script>
 
 <template>
@@ -26,7 +43,19 @@ const authStore = useAuthStore()
 
     <Column header="Status">
       <template #body="{ data }">
-        <Tag :value="data.status.text" :severity="data.status.severity" />
+        <Tag :severity="data.status.severity">
+          <template #default>
+            <div class="flex items-center">
+              <span>{{ data.status.text }}</span>
+              <span
+                v-if="data.status.isRunning && data.status.startedAt"
+                class="ml-1"
+                v-html="formatDuration(data.status.startedAt)"
+              >
+              </span>
+            </div>
+          </template>
+        </Tag>
       </template>
     </Column>
 

--- a/src/components/JobStatusTag.vue
+++ b/src/components/JobStatusTag.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { BotStatus } from '@/types/bots';
+
+const props = defineProps<{
+  status: BotStatus;
+}>();
+
+const durationDisplayParts = computed(() => {
+  if (props.status.isRunning && props.status.startedAt) {
+    return formatDuration(props.status.startedAt);
+  }
+  return null;
+});
+</script>
+
+<template>
+  <Tag :severity="status.severity">
+    <template #default>
+      <span>{{ status.text }}</span>
+      <template v-if="durationDisplayParts">
+        <span class="ml-1">
+          for {{ durationDisplayParts.hours }}:{{ durationDisplayParts.minutes }}<span class="text-xs">:{{ durationDisplayParts.seconds }}</span>
+        </span>
+      </template>
+    </template>
+  </Tag>
+</template>

--- a/src/composables/useBotStatus.ts
+++ b/src/composables/useBotStatus.ts
@@ -20,11 +20,13 @@ export const useBotStatus = () => {
       state = 'pending'
     } else if (statusLower.includes("pod in 'running' phase")) {
       state = 'running'
-      // Try to parse Started at time
       const startedAtIndex = statusLong.indexOf("Started at '")
       if (startedAtIndex !== -1) {
         const dateString = statusLong.substring(startedAtIndex + 12, statusLong.indexOf("'", startedAtIndex + 12))
-        startedAt = new Date(dateString)
+        const parsedStartedAt = new Date(dateString)
+        if (!isNaN(parsedStartedAt.getTime())) {
+          startedAt = parsedStartedAt
+        }
       }
     } else if (statusLower.includes('error') || statusLower.includes('failed')) {
       state = 'error'
@@ -32,13 +34,13 @@ export const useBotStatus = () => {
       state = 'stopped'
     }
 
-    const baseStatus = {
+    const baseStatus: BotStatus = {
       state,
       ...STATUS_CONFIG[state],
       isPending: state === 'pending',
     }
 
-    if (startedAt && !isNaN(startedAt.getTime())) {
+    if (startedAt) {
       return { ...baseStatus, startedAt }
     }
     return baseStatus

--- a/src/composables/useFormatDuration.ts
+++ b/src/composables/useFormatDuration.ts
@@ -1,0 +1,24 @@
+export interface FormattedDuration {
+  hours: string
+  minutes: string
+  seconds: string
+}
+
+const pad = (num: number): string => num.toString().padStart(2, '0')
+
+export const formatDuration = (startedAt: Date): FormattedDuration => {
+  const diffMs = new Date().getTime() - startedAt.getTime()
+
+  const currentTotalSeconds = Math.floor(diffMs / 1000)
+  const totalSeconds = Math.max(0, currentTotalSeconds)
+
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  return {
+    hours: pad(hours),
+    minutes: pad(minutes),
+    seconds: pad(seconds),
+  }
+}

--- a/src/types/bots.ts
+++ b/src/types/bots.ts
@@ -12,6 +12,7 @@ export type BotStatus = {
   severity: 'success' | 'danger' | 'info'
   isRunning: boolean
   isPending: boolean
+  startedAt?: Date
 }
 
 export interface Bot {


### PR DESCRIPTION
- Shows 'Running for HH:MM:SS' for active jobs.
- Seconds are displayed in a smaller font size using Tailwind CSS.
- Parses 'Started at' time from job's status_long.
- Updated PrimeVue Tag component usage to use default slot explicitly.