### PR TITLE
Fix: Map CrashLoopBackOff to error status and display details

### DIFF
--- a/src/components/JobStatusTag.vue
+++ b/src/components/JobStatusTag.vue
@@ -16,12 +16,17 @@ const durationDisplayParts = computed(() => {
 <template>
   <Tag :severity="status.severity">
     <template #default>
-      <span>{{ status.text }}</span>
-      <template v-if="durationDisplayParts">
-        <span class="ml-1">
-          for {{ durationDisplayParts.hours }}:{{ durationDisplayParts.minutes }}<span class="text-xs">:{{ durationDisplayParts.seconds }}</span>
-        </span>
-      </template>
+      <div>
+        <span>{{ status.text }}</span>
+        <template v-if="durationDisplayParts">
+          <span class="ml-1">
+            for {{ durationDisplayParts.hours }}:{{ durationDisplayParts.minutes }}<span class="text-xs">:{{ durationDisplayParts.seconds }}</span>
+          </span>
+        </template>
+      </div>
+      <div v-if="status.state === 'error'" class="mt-1 text-xs">
+        {{ status.status_long }}
+      </div>
     </template>
   </Tag>
 </template>

--- a/src/composables/useBotStatus.ts
+++ b/src/composables/useBotStatus.ts
@@ -28,7 +28,7 @@ export const useBotStatus = () => {
           startedAt = parsedStartedAt
         }
       }
-    } else if (statusLower.includes('error') || statusLower.includes('failed')) {
+    } else if (statusLower.includes('error') || statusLower.includes('failed') || statusLower.includes('crashloopbackoff')) {
       state = 'error'
     } else {
       state = 'stopped'
@@ -38,6 +38,7 @@ export const useBotStatus = () => {
       state,
       ...STATUS_CONFIG[state],
       isPending: state === 'pending',
+      status_long: statusLong,
     }
 
     if (startedAt) {

--- a/src/types/bots.ts
+++ b/src/types/bots.ts
@@ -13,6 +13,7 @@ export type BotStatus = {
   isRunning: boolean
   isPending: boolean
   startedAt?: Date
+  status_long: string
 }
 
 export interface Bot {


### PR DESCRIPTION
- Updated BotStatus type to include status_long.
- Modified useBotStatus composable to correctly identify CrashLoopBackOff as an error state and populate status_long.
- Updated JobStatusTag component to display status_long on a new line for error states.