### PR TITLE
fix: apply post-review improvements to useCategoryValidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,10 @@ Real-time features use WebSocket connections defined in AsyncAPI contract (`src/
 
 **AbortController signal capture:** When using `AbortController` in async functions, always capture `signal` from the controller before the `await` (`const { signal } = abortController`) and use `signal.aborted` — not `abortController?.signal.aborted` — in `finally` blocks. The shared `abortController` variable may be reassigned by a subsequent call before the current `finally` runs, causing the wrong signal to be checked.
 
+## Wikimedia Commons API
+
+**Titles per request limit:** The `action=query&titles=` parameter accepts at most 50 titles for non-bot users (500 with `apihighlimits`). Both `useTitleVerification.ts` and `useCategoryValidation.ts` chunk requests at 50 using a `for (let i = 0; i < items.length; i += 50)` loop with a shared `AbortController` signal checked at the top of each iteration.
+
 ## PrimeVue Component Patterns
 
 **DatePicker events:** Use `@update:model-value` as the single handler for all date changes (selection and clear). The separate `@date-select` and `@clear` events are unreliable — `@clear` may not fire when `show-clear` is used. Emit downstream events (e.g., `dateChange`) from `@update:model-value` instead.

--- a/src/composables/__tests__/useCategoryValidation.test.ts
+++ b/src/composables/__tests__/useCategoryValidation.test.ts
@@ -64,6 +64,7 @@ describe('useCategoryValidation', () => {
       ['single-bracket link', '[Category:Foo]'],
       ['two opening one closing bracket', '[[Category:Foo]'],
       ['one opening two closing brackets', '[Category:Foo]]'],
+      ['whitespace-only name', '[[Category:   ]]'],
     ])('returns [] for %s', (_, input) => {
       expect(parseCategoryNames(input)).toEqual([])
     })
@@ -79,15 +80,17 @@ describe('useCategoryValidation', () => {
       ['leading and trailing whitespace', '[[Category:  Foo  ]]', 'Foo'],
       ['pipe alias', '[[Category:Foo|display text]]', 'Foo'],
       ['trailing space before sort key', '[[Category:Foo |sort key]]', 'Foo'],
+      ['underscores replaced with spaces', '[[Category:Foo_Bar_Baz]]', 'Foo Bar Baz'],
     ])('extracts name from %s', (_, input, expected) => {
       expect(parseCategoryNames(input)).toEqual([expected])
     })
 
     it.each([
-      ['identical names', '[[Category:Foo]]\n[[Category:Foo]]'],
-      ['names differing only by trailing space', '[[Category:Foo ]]\n[[Category:Foo]]'],
-    ])('deduplicates %s', (_, input) => {
-      expect(parseCategoryNames(input)).toEqual(['Foo'])
+      ['identical names', '[[Category:Foo]]\n[[Category:Foo]]', ['Foo']],
+      ['names differing only by trailing space', '[[Category:Foo ]]\n[[Category:Foo]]', ['Foo']],
+      ['names differing only by underscores vs spaces', '[[Category:Foo_Bar]]\n[[Category:Foo Bar]]', ['Foo Bar']],
+    ])('deduplicates %s', (_, input, expected) => {
+      expect(parseCategoryNames(input)).toEqual(expected)
     })
 
     it('extracts multiple category names', () => {
@@ -140,11 +143,9 @@ describe('useCategoryValidation', () => {
         input: '[[Category:Photography in Berlin]]',
       },
       {
-        label: 'API normalises the title',
+        label: 'category with underscores exists on Commons',
         pages: [{ title: 'Category:Photography in Berlin' }] as QueryPage[],
-        normalized: [
-          { from: 'Category:Photography_in_Berlin', to: 'Category:Photography in Berlin' },
-        ] as QueryNormalized[],
+        normalized: [] as QueryNormalized[],
         input: '[[Category:Photography_in_Berlin]]',
       },
     ])('does not report category as missing when $label', async ({ pages, normalized, input }) => {
@@ -172,15 +173,6 @@ describe('useCategoryValidation', () => {
         input: '[[Category:Photography in Berlin]]',
         expectedMissing: [] as string[],
       },
-      {
-        label: 'confirmed to exist via normalisation',
-        pages: [{ title: 'Category:Photography in Berlin' }] as QueryPage[],
-        normalized: [
-          { from: 'Category:Photography_in_Berlin', to: 'Category:Photography in Berlin' },
-        ] as QueryNormalized[],
-        input: '[[Category:Photography_in_Berlin]]',
-        expectedMissing: [] as string[],
-      },
     ])(
       'does not re-query category $label',
       async ({ pages, normalized, input, expectedMissing }) => {
@@ -193,7 +185,7 @@ describe('useCategoryValidation', () => {
         for (const exec of [...pendingDebounceExecutors]) await exec()
         pendingDebounceExecutors = []
 
-        store.globalCategories = input + '\n'
+        store.globalCategories = `${input}\n`
         for (const exec of pendingDebounceExecutors) await exec()
 
         expect(mockFetch.mock.calls).toHaveLength(1)
@@ -201,69 +193,32 @@ describe('useCategoryValidation', () => {
       },
     )
 
-    it('keeps isChecking true when a second request aborts the first', async () => {
-      let resolveFirst!: () => void
-      let resolveSecond!: () => void
-      let callCount = 0
+    it('sends categories in batches of 50 when there are more than 50', async () => {
+      const catNames = Array.from({ length: 51 }, (_, i) => `Cat${i + 1}`)
+      const allPages = catNames.map((name) => ({ title: `Category:${name}` }))
 
+      let callCount = 0
       global.fetch = mock(() => {
-        callCount += 1
-        const promise = new Promise<void>((res) => {
-          if (callCount === 1) resolveFirst = res
-          else resolveSecond = res
-        })
-        return promise.then(() => ({
+        const chunk = callCount === 0 ? allPages.slice(0, 50) : allPages.slice(50)
+        callCount++
+        return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ query: { pages: {} } }),
-        }))
+          json: () =>
+            Promise.resolve({
+              query: {
+                pages: Object.fromEntries(chunk.map((p, i) => [String(i), p])),
+              },
+            }),
+        })
       }) as unknown as typeof fetch
 
-      store.globalCategories = '[[Category:Foo]]'
-      const { isChecking } = useCategoryValidation()
+      store.globalCategories = catNames.map((name) => `[[Category:${name}]]`).join('\n')
+      const { missingCategories } = useCategoryValidation()
 
-      // Start first request
-      const firstExec = pendingDebounceExecutors.shift()!
-      const firstPromise = firstExec()
+      for (const exec of pendingDebounceExecutors) await exec()
 
-      // Trigger second request (aborts first) via watcher
-      store.globalCategories = '[[Category:Bar]]'
-      await nextTick()
-      const secondExec = pendingDebounceExecutors.shift()!
-      const secondPromise = secondExec()
-
-      // Resolve first (it is aborted — its finally must NOT clear isChecking)
-      resolveFirst()
-      await firstPromise
-
-      expect(isChecking.value).toBe(true)
-
-      resolveSecond()
-      await secondPromise
-      expect(isChecking.value).toBe(false)
-    })
-
-    it('sets isChecking to true during the API call and false after', async () => {
-      let resolveFetch!: () => void
-      const fetchPromise = new Promise<void>((res) => {
-        resolveFetch = res
-      })
-
-      global.fetch = mock(() =>
-        fetchPromise.then(() => ({
-          ok: true,
-          json: () => Promise.resolve({ query: { pages: {} } }),
-        })),
-      ) as unknown as typeof fetch
-
-      store.globalCategories = '[[Category:Foo]]'
-      const { isChecking } = useCategoryValidation()
-
-      const execPromises = pendingDebounceExecutors.map((exec) => exec())
-      expect(isChecking.value).toBe(true)
-
-      resolveFetch()
-      await Promise.all(execPromises)
-      expect(isChecking.value).toBe(false)
+      expect((global.fetch as unknown as ReturnType<typeof mock>).mock.calls).toHaveLength(2)
+      expect(missingCategories.value).toEqual([])
     })
 
     it.each([

--- a/src/composables/useCategoryValidation.ts
+++ b/src/composables/useCategoryValidation.ts
@@ -8,15 +8,18 @@ export type QueryNormalized = { from: string; to: string }
 const COMMONS_API_URL = 'https://commons.wikimedia.org/w/api.php'
 const CATEGORY_REGEX = /\[\[Category:([^\]|]+)(?:\|[^\]]+)?\]\]/gi
 const DEBOUNCE_MS = 500
+const TITLES_PER_REQUEST = 50
 
 export const parseCategoryNames = (text: string): string[] => {
   const matches = [...text.matchAll(CATEGORY_REGEX)]
   return [
     ...new Set(
-      matches.map((m) => {
-        const name = m[1]!.trim()
-        return name.charAt(0).toUpperCase() + name.slice(1)
-      }),
+      matches
+        .map((m) => {
+          const name = m[1]!.trim().replace(/_/g, ' ')
+          return name ? name.charAt(0).toUpperCase() + name.slice(1) : null
+        })
+        .filter((n): n is string => n !== null),
     ),
   ]
 }
@@ -25,7 +28,6 @@ export const useCategoryValidation = () => {
   const store = useCollectionsStore()
 
   const missingCategories = ref<string[]>([])
-  const isChecking = ref(false)
   const queriedCategories = new Set<string>()
   const existingCategories = new Set<string>()
   let abortController: AbortController | null = null
@@ -45,53 +47,51 @@ export const useCategoryValidation = () => {
       abortController = new AbortController()
       const { signal } = abortController
 
-      isChecking.value = true
-
-      const params = new URLSearchParams()
-      params.set('action', 'query')
-      params.set('titles', toQuery.map((name) => `Category:${name}`).join('|'))
-      params.set('format', 'json')
-      params.set('origin', '*')
-      params.set('formatversion', '2')
-
       try {
-        const res = await fetch(COMMONS_API_URL, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: params.toString(),
-          signal,
-        })
+        for (let i = 0; i < toQuery.length; i += TITLES_PER_REQUEST) {
+          if (signal.aborted) return
 
-        if (signal.aborted) return
-        if (!res.ok) return
+          const chunk = toQuery.slice(i, i + TITLES_PER_REQUEST)
+          const params = new URLSearchParams()
+          params.set('action', 'query')
+          params.set('titles', chunk.map((name) => `Category:${name}`).join('|'))
+          params.set('format', 'json')
+          params.set('origin', '*')
+          params.set('formatversion', '2')
 
-        const data = (await res.json()) as {
-          query?: {
-            normalized?: QueryNormalized[]
-            pages?: Record<string, QueryPage>
+          const res = await fetch(COMMONS_API_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString(),
+            signal,
+          })
+
+          if (signal.aborted) return
+          if (!res.ok) return
+
+          const data = (await res.json()) as {
+            query?: {
+              normalized?: QueryNormalized[]
+              pages?: Record<string, QueryPage>
+            }
           }
-        }
 
-        // Map normalised title → original queried name so cache lookups use the input form
-        const normalizedToOriginal = new Map<string, string>()
-        for (const { from, to } of data.query?.normalized ?? []) {
-          normalizedToOriginal.set(to.replace(/^Category:/, ''), from.replace(/^Category:/, ''))
-        }
+          const normalizedToOriginal = new Map<string, string>()
+          for (const { from, to } of data.query?.normalized ?? []) {
+            normalizedToOriginal.set(to.replace(/^Category:/, ''), from.replace(/^Category:/, ''))
+          }
 
-        for (const page of Object.values(data.query?.pages ?? {})) {
-          const normalizedName = page.title.replace(/^Category:/, '')
-          const originalName = normalizedToOriginal.get(normalizedName) ?? normalizedName
-          queriedCategories.add(originalName)
-          if (!page.missing) {
-            existingCategories.add(originalName)
+          for (const page of Object.values(data.query?.pages ?? {})) {
+            const normalizedName = page.title.replace(/^Category:/, '')
+            const originalName = normalizedToOriginal.get(normalizedName) ?? normalizedName
+            queriedCategories.add(originalName)
+            if (!page.missing) {
+              existingCategories.add(originalName)
+            }
           }
         }
       } catch (e: unknown) {
         if (e instanceof Error && e.name === 'AbortError') return
-      } finally {
-        if (!signal.aborted) {
-          isChecking.value = false
-        }
       }
     }
 
@@ -106,5 +106,5 @@ export const useCategoryValidation = () => {
     { immediate: true },
   )
 
-  return { missingCategories, isChecking }
+  return { missingCategories }
 }


### PR DESCRIPTION
- Remove unused `isChecking` state (was returned but never consumed by any component)
- Normalize underscores to spaces in `parseCategoryNames` (MediaWiki treats them interchangeably; normalizing upfront deduplicates underscore/space variants before querying)
- Filter empty/whitespace-only category names (e.g. `[[Category:  ]]` would previously query `Category:`)
- Chunk API requests at 50 titles per request to respect the MediaWiki API limit for non-bot users
- Document the 50-title limit in CLAUDE.md

Follows up on Gemini's review of https://github.com/DaxServer/wikibots-curator-frontend/pull/186