### PR TITLE
refactor: remove last_edited_by field from upload requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ bun generate
    - `channels/wsChannel/messages/` - Channel reference
    - `operations/ServerMessage/messages/` - Server operation (alphabetical order)
 
+**Generator type inference:** `bun generate` uses `tsc` to infer template literal types from JSON schema patterns (e.g., `ItemId = \`Q${number}\``). If these degrade to `string` after a dep bump, the cause is likely a new TypeScript error (e.g., TS5112 in TS 6.0) polluting the `tsc` output. The fix is adding the relevant suppression flag to the `Bun.spawnSync` call in `getInferredType()` in `scripts/asyncapi.ts`.
+
 ## Technology Stack
 
 - **Vue 3** with Composition API (`<script setup lang="ts">`)

--- a/asyncapi.json
+++ b/asyncapi.json
@@ -555,9 +555,6 @@
           "success": {
             "type": "string"
           },
-          "last_edited_by": {
-            "type": "string"
-          },
           "created_at": {
             "type": "string",
             "format": "date-time"

--- a/scripts/asyncapi.ts
+++ b/scripts/asyncapi.ts
@@ -322,6 +322,7 @@ const getInferredType = async (pattern: string): Promise<string> => {
       'bundler',
       '--module',
       'esnext',
+      '--ignoreConfig',
     ])
 
     // Bun.spawnSync doesn't throw on non-zero exit code by default,

--- a/scripts/asyncapi.ts
+++ b/scripts/asyncapi.ts
@@ -299,7 +299,10 @@ const getInferredType = async (pattern: string): Promise<string> => {
     `temp_type_${Math.random().toString(36).slice(2)}.ts`,
   )
   // Simplify pattern for type inference to avoid "excessively deep" errors
-  const simplifiedPattern = pattern.replace(/\[1-9\]/g, '\\d').replace(/\[0-9\]/g, '\\d')
+  const simplifiedPattern = pattern
+    .replace(/\[1-9\]/g, '\\d')
+    .replace(/\[0-9\]/g, '\\d')
+    .replace(/\\d\\d\*/g, '\\d+')
 
   // Escape backslashes for the TS file string literal
   const escapedPattern = simplifiedPattern.replace(/\\/g, '\\\\').replace(/'/g, "\\'")

--- a/src/components/views/BatchUploadsView.vue
+++ b/src/components/views/BatchUploadsView.vue
@@ -110,14 +110,6 @@ const hasPendingJobs = computed(() => {
   return computedStats.value.queued > 0 || computedStats.value.in_progress > 0
 })
 
-const lastEditedBy = computed(() => {
-  const users = new Set(
-    store.batchUploads.map((u) => u.last_edited_by).filter((u): u is string => !!u),
-  )
-  if (users.size === 0) return null
-  return Array.from(users).join(', ')
-})
-
 const handleAdminRetrySelectedUploads = async () => {
   await adminRetrySelectedUploads(Array.from(selectedIds.value), batchId.value)
   exitSelectionMode()
@@ -259,16 +251,6 @@ onUnmounted(() => {
             <i class="pi pi-user text-sm"></i>
             <span v-if="store.batch">{{ store.batch.username }}</span>
             <Skeleton v-else />
-            <SimpleMessage
-              v-if="lastEditedBy"
-              icon="pi pi-user-edit"
-              severity="warn"
-              v-tooltip.top="
-                'The edits will be made from this user account. See history of files on Commons.'
-              "
-            >
-              Retry triggered by: {{ lastEditedBy }}
-            </SimpleMessage>
           </div>
         </template>
         <template #content>

--- a/src/composables/__tests__/useAdmin.test.ts
+++ b/src/composables/__tests__/useAdmin.test.ts
@@ -20,7 +20,6 @@ const makeUploadRequest = (id: number, status: string): AdminUploadRequest => ({
   result: null,
   error: undefined,
   success: null,
-  last_edited_by: null,
   celery_task_id: null,
   created_at: '2026-01-01T00:00:00',
   updated_at: '2026-01-01T00:00:00',

--- a/src/composables/__tests__/useBatchSelection.test.ts
+++ b/src/composables/__tests__/useBatchSelection.test.ts
@@ -15,7 +15,6 @@ describe('useBatchSelection', () => {
     wikitext: `{{Some text}}`,
     error: undefined,
     success: '',
-    last_edited_by: undefined,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   })

--- a/src/composables/__tests__/useCategoryValidation.test.ts
+++ b/src/composables/__tests__/useCategoryValidation.test.ts
@@ -88,7 +88,11 @@ describe('useCategoryValidation', () => {
     it.each([
       ['identical names', '[[Category:Foo]]\n[[Category:Foo]]', ['Foo']],
       ['names differing only by trailing space', '[[Category:Foo ]]\n[[Category:Foo]]', ['Foo']],
-      ['names differing only by underscores vs spaces', '[[Category:Foo_Bar]]\n[[Category:Foo Bar]]', ['Foo Bar']],
+      [
+        'names differing only by underscores vs spaces',
+        '[[Category:Foo_Bar]]\n[[Category:Foo Bar]]',
+        ['Foo Bar'],
+      ],
     ])('deduplicates %s', (_, input, expected) => {
       expect(parseCategoryNames(input)).toEqual(expected)
     })

--- a/src/composables/__tests__/useDataFilters.test.ts
+++ b/src/composables/__tests__/useDataFilters.test.ts
@@ -20,7 +20,6 @@ describe('useDataFilters', () => {
     error: error ? { message: error, type: 'error' } : undefined,
     success:
       status === UPLOAD_STATUS.Completed ? 'https://commons.wikimedia.org/wiki/File:Test.jpg' : '',
-    last_edited_by: undefined,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   })

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -33,7 +33,6 @@ export type AdminUploadRequest = {
   result: string | null
   error: UploadUpdateItem['error']
   success: string | null
-  last_edited_by: string | null
   celery_task_id: string | null
   created_at: string
   updated_at: string

--- a/src/types/asyncapi.ts
+++ b/src/types/asyncapi.ts
@@ -238,7 +238,6 @@ export type BatchUploadItem = {
     | GenericError
     | TitleBlacklistedError
   success?: string
-  last_edited_by?: string
   created_at?: string
   updated_at?: string
   image_id?: string
@@ -622,9 +621,9 @@ export enum DataValueType {
   WIKIBASE_ENTITYID = 'wikibase-entityid',
 }
 
-export type ItemId = `Q${number}`
+export type ItemId = string
 
-export type PropertyId = `P${number}`
+export type PropertyId = string
 
 export enum Rank {
   DEPRECATED = 'deprecated',

--- a/src/types/asyncapi.ts
+++ b/src/types/asyncapi.ts
@@ -621,9 +621,9 @@ export enum DataValueType {
   WIKIBASE_ENTITYID = 'wikibase-entityid',
 }
 
-export type ItemId = string
+export type ItemId = `Q${number}${number}`
 
-export type PropertyId = string
+export type PropertyId = `P${number}${number}`
 
 export enum Rank {
   DEPRECATED = 'deprecated',

--- a/src/types/asyncapi.ts
+++ b/src/types/asyncapi.ts
@@ -621,9 +621,9 @@ export enum DataValueType {
   WIKIBASE_ENTITYID = 'wikibase-entityid',
 }
 
-export type ItemId = `Q${number}${number}`
+export type ItemId = `Q${number}`
 
-export type PropertyId = `P${number}${number}`
+export type PropertyId = `P${number}`
 
 export enum Rank {
   DEPRECATED = 'deprecated',


### PR DESCRIPTION
refactor: remove last_edited_by field from upload requests

## Changes

- Remove `last_edited_by` from upload request payloads and all related types/tests
- Fix `bun generate` type inference regression caused by TypeScript 6.0 upgrade: TS 6.0 introduced error TS5112 when `tsc` is invoked with files on the CLI and a `tsconfig.json` exists nearby — add `--ignoreConfig` to suppress it and restore `ItemId`/`PropertyId` as template literal types
- Regenerate `src/types/asyncapi.ts` with correct types
- Document the generator type inference behaviour in CLAUDE.md
