### PR TITLE
fix: type FetchPresetsData.handler as ImageHandler enum

### DIFF
--- a/asyncapi.json
+++ b/asyncapi.json
@@ -1988,7 +1988,7 @@
         ],
         "properties": {
           "handler": {
-            "type": "string"
+            "$ref": "#/components/schemas/ImageHandler"
           }
         },
         "additionalProperties": false

--- a/src/components/mapillary/MapillaryCollections.vue
+++ b/src/components/mapillary/MapillaryCollections.vue
@@ -2,7 +2,7 @@
 const store = useCollectionsStore()
 
 onMounted(() => {
-  store.setHandler('mapillary')
+  store.setHandler(ImageHandler.MAPILLARY)
 })
 </script>
 

--- a/src/stores/collections.store.ts
+++ b/src/stores/collections.store.ts
@@ -1,12 +1,18 @@
-import type { BatchItem, BatchUploadItem, Creator, PresetItem } from '@/types/asyncapi'
-import type { Handler, Layout } from '@/types/collections'
+import {
+  ImageHandler,
+  type BatchItem,
+  type BatchUploadItem,
+  type Creator,
+  type PresetItem,
+} from '@/types/asyncapi'
+import type { Layout } from '@/types/collections'
 import type { Item, Metadata, MetadataKey } from '@/types/image'
 import { TITLE_ERROR_STATUSES } from '@/types/image'
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, shallowRef } from 'vue'
 
 export const useCollectionsStore = defineStore('collections', () => {
-  const handler = ref<Handler>('mapillary')
+  const handler = ref<ImageHandler>(ImageHandler.MAPILLARY)
   const input = ref<string>('')
   const creator = ref<Creator>({ id: '', username: '', profile_url: '' })
 
@@ -220,7 +226,7 @@ export const useCollectionsStore = defineStore('collections', () => {
     itemsPerPage.value = n
   }
 
-  const setHandler = (h: Handler) => {
+  const setHandler = (h: ImageHandler) => {
     handler.value = h
   }
 

--- a/src/types/asyncapi.ts
+++ b/src/types/asyncapi.ts
@@ -99,7 +99,7 @@ export type FetchPresets = {
 }
 
 export type FetchPresetsData = {
-  handler: string
+  handler: ImageHandler
 }
 
 export type CheckCategoriesDeleted = {


### PR DESCRIPTION
`FetchPresetsData.handler` was typed as `string` in the AsyncAPI schema while `FetchImages.handler` correctly used the `ImageHandler` enum ref. This caused a production `AttributeError` when the backend called `.value` on the string. The fix updates the schema so both use `$ref: ImageHandler`, regenerates the TypeScript types, and updates `MapillaryCollections.vue` and the collections store to use the enum value.