### PR TITLE
feat: sequence map in step 2

### DIFF
--- a/.biomelintrc-auto-import.json
+++ b/.biomelintrc-auto-import.json
@@ -484,6 +484,7 @@
       "useScriptTag",
       "useScroll",
       "useScrollLock",
+      "useSequenceMap",
       "useSessionStorage",
       "useShare",
       "useSlots",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,7 +294,7 @@ The title template system lives in `src/composables/useTitleTemplate.ts` and `sr
 
 - **License field** - `meta.license` exists in the data model and store but is intentionally not exposed in the Step 3 UI — Mapillary images use a fixed license so per-item and global license overrides are not applicable
 - **Handler** - Image source (currently only `mapillary`)
-- **Item** - An image with metadata (`Item` type in `types/image.ts`)
+- **Item** - An image with metadata (`Item` type in `types/image.ts`). `index` is 1-based.
 - **Batch** - A collection of uploads tracked together (`BatchItem` in AsyncAPI types)
 - **Title Status** - Validation state of generated titles (`TITLE_ERROR_STATUSES` in `types/image.ts`)
 - **Layout** - View mode (`list` or `grid`) for collection display
@@ -306,3 +306,13 @@ The title template system lives in `src/composables/useTitleTemplate.ts` and `sr
   Preset creation (via accordion "Create new preset" button) is treated like editing mode - hides images list until canceled/saved. Preset removal (via "Remove preset" button) enters manual mode with both forms and images list visible.
 
   Orchestration lives in `usePresetManager` composable (`selectPreset`, `clearPreset`, `handleEditPreset`, `handleCancelEdit`).
+
+## MapLibre GL JS Integration
+
+**Container setup:** Reference container by string `id` (not Vue `ref`). Set height via scoped CSS — MapLibre reads `clientHeight` at init before Tailwind JIT resolves.
+
+**Layer ordering:** Layers render in insertion order (first = bottom). Add background/direction layers before pin layers.
+
+**Paint expressions:** WebGL-based — CSS `var()` is not supported. Hardcode hex values.
+
+**OpenFreeMap liberty style** has known missing sprite icons — cosmetic warnings, safe to ignore. Use `positron` for a cleaner minimal style.

--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -106,6 +106,7 @@ declare global {
   const isRef: typeof import('vue').isRef
   const isShallow: typeof import('vue').isShallow
   const isValidExtension: typeof import('./src/utils/titleTemplate').isValidExtension
+  const itemsToGeoJSON: typeof import('./src/composables/useSequenceMap').itemsToGeoJSON
   const makeDestructurable: typeof import('@vueuse/core').makeDestructurable
   const makePreset: typeof import('./src/__tests__/fixtures').makePreset
   const mapActions: typeof import('pinia').mapActions
@@ -326,6 +327,7 @@ declare global {
   const useScriptTag: typeof import('@vueuse/core').useScriptTag
   const useScroll: typeof import('@vueuse/core').useScroll
   const useScrollLock: typeof import('@vueuse/core').useScrollLock
+  const useSequenceMap: typeof import('./src/composables/useSequenceMap').useSequenceMap
   const useSessionStorage: typeof import('@vueuse/core').useSessionStorage
   const useShare: typeof import('@vueuse/core').useShare
   const useSlots: typeof import('vue').useSlots
@@ -767,6 +769,7 @@ declare module 'vue' {
     readonly useScriptTag: UnwrapRef<typeof import('@vueuse/core')['useScriptTag']>
     readonly useScroll: UnwrapRef<typeof import('@vueuse/core')['useScroll']>
     readonly useScrollLock: UnwrapRef<typeof import('@vueuse/core')['useScrollLock']>
+    readonly useSequenceMap: UnwrapRef<typeof import('./src/composables/useSequenceMap')['useSequenceMap']>
     readonly useSessionStorage: UnwrapRef<typeof import('@vueuse/core')['useSessionStorage']>
     readonly useShare: UnwrapRef<typeof import('@vueuse/core')['useShare']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@vueuse/core": "^14.2.1",
         "@vueuse/router": "^14.2.1",
         "handlebars": "^4.7.9",
+        "maplibre-gl": "^5.23.0",
         "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
         "primevue": "^4.5.5",
@@ -20,8 +21,8 @@
       },
       "devDependencies": {
         "@asyncapi/modelina": "^5.10.1",
-        "@biomejs/biome": "^2.4.11",
-        "@happy-dom/global-registrator": "^20.8.9",
+        "@biomejs/biome": "^2.4.12",
+        "@happy-dom/global-registrator": "^20.9.0",
         "@pinia/testing": "^1.0.3",
         "@primevue/auto-import-resolver": "^4.5.5",
         "@tailwindcss/vite": "^4.2.2",
@@ -30,16 +31,16 @@
         "@types/bun": "1.3.12",
         "@types/handlebars": "^4.1.0",
         "@types/node": "^25.6.0",
-        "@vitejs/plugin-vue": "^6.0.5",
+        "@vitejs/plugin-vue": "^6.0.6",
         "@vue/tsconfig": "^0.9.1",
         "@vue/typescript-plugin": "^3.2.6",
         "arkregex": "^0.0.5",
-        "happy-dom": "^20.8.9",
+        "happy-dom": "^20.9.0",
         "jiti": "^2.6.1",
-        "prettier": "^3.8.2",
+        "prettier": "^3.8.3",
         "prettier-plugin-organize-imports": "^4.3.0",
         "tailwindcss": "^4.2.2",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "unplugin-auto-import": "^21.0.0",
         "unplugin-vue-components": "^32.0.0",
         "vite": "^8.0.8",
@@ -193,6 +194,26 @@
     "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
 
     "@jsep-plugin/ternary": ["@jsep-plugin/ternary@1.1.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-ck5wiqIbqdMX6WRQztBL7ASDty9YLgJ3sSAK5ZpBzXeySvFGCzIvM6UiAI4hTZ22fEcYQVV/zhUbNscggW+Ukg=="],
+
+    "@mapbox/jsonlint-lines-primitives": ["@mapbox/jsonlint-lines-primitives@2.0.2", "", {}, "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ=="],
+
+    "@mapbox/point-geometry": ["@mapbox/point-geometry@1.1.0", "", {}, "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ=="],
+
+    "@mapbox/tiny-sdf": ["@mapbox/tiny-sdf@2.1.0", "", {}, "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg=="],
+
+    "@mapbox/unitbezier": ["@mapbox/unitbezier@0.0.1", "", {}, "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="],
+
+    "@mapbox/vector-tile": ["@mapbox/vector-tile@2.0.4", "", { "dependencies": { "@mapbox/point-geometry": "~1.1.0", "@types/geojson": "^7946.0.16", "pbf": "^4.0.1" } }, "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg=="],
+
+    "@mapbox/whoots-js": ["@mapbox/whoots-js@3.1.0", "", {}, "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="],
+
+    "@maplibre/geojson-vt": ["@maplibre/geojson-vt@6.1.0", "", { "dependencies": { "kdbush": "^4.0.2" } }, "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ=="],
+
+    "@maplibre/maplibre-gl-style-spec": ["@maplibre/maplibre-gl-style-spec@24.8.1", "", { "dependencies": { "@mapbox/jsonlint-lines-primitives": "~2.0.2", "@mapbox/unitbezier": "^0.0.1", "json-stringify-pretty-compact": "^4.0.0", "minimist": "^1.2.8", "quickselect": "^3.0.0", "rw": "^1.3.3", "tinyqueue": "^3.0.0" }, "bin": { "gl-style-migrate": "dist/gl-style-migrate.mjs", "gl-style-validate": "dist/gl-style-validate.mjs", "gl-style-format": "dist/gl-style-format.mjs" } }, "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw=="],
+
+    "@maplibre/mlt": ["@maplibre/mlt@1.1.8", "", { "dependencies": { "@mapbox/point-geometry": "^1.1.0" } }, "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg=="],
+
+    "@maplibre/vt-pbf": ["@maplibre/vt-pbf@4.3.0", "", { "dependencies": { "@mapbox/point-geometry": "^1.1.0", "@mapbox/vector-tile": "^2.0.4", "@maplibre/geojson-vt": "^5.0.4", "@types/geojson": "^7946.0.16", "@types/supercluster": "^7.1.3", "pbf": "^4.0.1", "supercluster": "^8.0.1" } }, "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
@@ -356,6 +377,8 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
     "@types/handlebars": ["@types/handlebars@4.1.0", "", { "dependencies": { "handlebars": "*" } }, "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -363,6 +386,8 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/protocol-buffers-schema": ["@types/protocol-buffers-schema@3.4.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-8cCg6BiIj4jS0LXUFq3sndmd46yyPLYqMzvXLcTM1MRubh3sfZlQiehoCjGDxSHTqGSjjx8EtVNryIAl0njQWg=="],
+
+    "@types/supercluster": ["@types/supercluster@7.1.3", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA=="],
 
     "@types/urijs": ["@types/urijs@1.19.26", "", {}, "sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg=="],
 
@@ -560,6 +585,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "earcut": ["earcut@3.0.2", "", {}, "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -633,6 +660,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
+
+    "gl-matrix": ["gl-matrix@3.4.4", "", {}, "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="],
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -742,6 +771,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json-stringify-pretty-compact": ["json-stringify-pretty-compact@4.0.0", "", {}, "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@2.2.1", "", {}, "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="],
@@ -751,6 +782,8 @@
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
     "just-curry-it": ["just-curry-it@5.3.0", "", {}, "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw=="],
+
+    "kdbush": ["kdbush@4.0.2", "", {}, "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="],
 
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
 
@@ -798,6 +831,8 @@
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
+    "maplibre-gl": ["maplibre-gl@5.23.0", "", { "dependencies": { "@mapbox/jsonlint-lines-primitives": "^2.0.2", "@mapbox/point-geometry": "^1.1.0", "@mapbox/tiny-sdf": "^2.0.7", "@mapbox/unitbezier": "^0.0.1", "@mapbox/vector-tile": "^2.0.4", "@mapbox/whoots-js": "^3.1.0", "@maplibre/geojson-vt": "^6.1.0", "@maplibre/maplibre-gl-style-spec": "^24.8.1", "@maplibre/mlt": "^1.1.8", "@maplibre/vt-pbf": "^4.3.0", "@types/geojson": "^7946.0.16", "earcut": "^3.0.2", "gl-matrix": "^3.4.4", "kdbush": "^4.0.2", "murmurhash-js": "^1.0.0", "pbf": "^4.0.1", "potpack": "^2.1.0", "quickselect": "^3.0.0", "tinyqueue": "^3.0.0" } }, "sha512-aou8YBNFS8uVtDWFWt0W/6oorfl18wt+oIA8fnXk1kivjkbtXi9gGrQvflTpwrR3hG13aWdIdbYWeN0NFMV7ag=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
@@ -815,6 +850,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
+    "murmurhash-js": ["murmurhash-js@1.0.0", "", {}, "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -866,6 +903,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pbf": ["pbf@4.0.1", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA=="],
+
     "perfect-debounce": ["perfect-debounce@2.0.0", "", {}, "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -882,6 +921,8 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "potpack": ["potpack@2.1.0", "", {}, "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ=="],
+
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "prettier-plugin-organize-imports": ["prettier-plugin-organize-imports@4.3.0", "", { "peerDependencies": { "prettier": ">=2.0", "typescript": ">=2.9", "vue-tsc": "^2.1.0 || 3" }, "optionalPeers": ["vue-tsc"] }, "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw=="],
@@ -892,11 +933,15 @@
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
+    "protocol-buffers-schema": ["protocol-buffers-schema@3.6.1", "", {}, "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ=="],
+
     "pubsub-js": ["pubsub-js@1.9.5", "", {}, "sha512-5MZ0I9i5JWVO7SizvOviKvZU2qaBbl2KQX150FAA+fJBwYpwOUId7aNygURWSdPzlsA/xZ/InUKXqBbzM0czTA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
+
+    "quickselect": ["quickselect@3.0.0", "", {}, "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="],
 
     "ramldt2jsonschema": ["ramldt2jsonschema@1.2.3", "", { "dependencies": { "commander": "^5.0.0", "js-yaml": "^3.14.0", "json-schema-migrate": "^0.2.0", "webapi-parser": "^0.5.0" }, "bin": { "dt2js": "bin/dt2js.js", "js2dt": "bin/js2dt.js" } }, "sha512-+wLDAV2NNv9NkfEUOYStaDu/6RYgYXeC1zLtXE+dMU/jDfjpN4iJnBGycDwFTFaIQGosOQhxph7fEX6Mpwxdug=="],
 
@@ -910,11 +955,15 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "resolve-protobuf-schema": ["resolve-protobuf-schema@2.1.0", "", { "dependencies": { "protocol-buffers-schema": "^3.3.1" } }, "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ=="],
+
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
 
@@ -974,6 +1023,8 @@
 
     "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
 
+    "supercluster": ["supercluster@8.0.1", "", { "dependencies": { "kdbush": "^4.0.2" } }, "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ=="],
+
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
@@ -983,6 +1034,8 @@
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyqueue": ["tinyqueue@3.0.0", "", {}, "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
@@ -1139,6 +1192,8 @@
     "@hyperjump/json-schema-core/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "@hyperjump/pact/just-curry-it": ["just-curry-it@3.2.1", "", {}, "sha512-Q8206k8pTY7krW32cdmPsP+DqqLgWx/hYPSj9/+7SYqSqz7UuwPbfSe07lQtvuuaVyiSJveXk0E5RydOuWwsEg=="],
+
+    "@maplibre/vt-pbf/@maplibre/geojson-vt": ["@maplibre/geojson-vt@5.0.4", "", {}, "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ=="],
 
     "@stoplight/json/safe-stable-stringify": ["safe-stable-stringify@1.1.1", "", {}, "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="],
 

--- a/components.d.ts
+++ b/components.d.ts
@@ -80,6 +80,7 @@ declare module 'vue' {
     Select: typeof import('primevue/select')['default']
     SelectButton: typeof import('primevue/selectbutton')['default']
     SelectionItem: typeof import('./src/components/ui/SelectionItem.vue')['default']
+    SequenceMap: typeof import('./src/components/collection/SequenceMap.vue')['default']
     SharedDataTable: typeof import('./src/components/layout/SharedDataTable.vue')['default']
     SimpleMessage: typeof import('./src/components/feedback/SimpleMessage.vue')['default']
     Skeleton: typeof import('primevue/skeleton')['default']

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@vueuse/core": "^14.2.1",
     "@vueuse/router": "^14.2.1",
     "handlebars": "^4.7.9",
+    "maplibre-gl": "^5.23.0",
     "pinia": "^3.0.4",
     "primeicons": "^7.0.0",
     "primevue": "^4.5.5",

--- a/src/components/collection/CollectionsTable.vue
+++ b/src/components/collection/CollectionsTable.vue
@@ -20,7 +20,7 @@ const onStepperUpdate = (next: string) => {
 
 <template>
   <div :class="['flex flex-col gap-4', store.stepper !== '3' && 'max-w-7xl mx-auto']">
-    <div :class="store.stepper === '3' && 'max-w-7xl mx-auto'">
+    <div :class="store.stepper === '3' && 'max-w-7xl mx-auto w-full'">
       <Stepper
         :value="store.stepper"
         @update:value="onStepperUpdate"
@@ -81,6 +81,8 @@ const onStepperUpdate = (next: string) => {
       :total-images="store.totalImages"
       :id-label="idLabel"
     />
+
+    <SequenceMap v-if="store.stepper === '2'" />
 
     <SdcWarningMessage v-if="store.stepper === '2' && store.anyItemsWithExistingFiles" />
 

--- a/src/components/collection/SequenceMap.vue
+++ b/src/components/collection/SequenceMap.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import maplibregl from 'maplibre-gl'
+import 'maplibre-gl/dist/maplibre-gl.css'
+
+const { geoJSON } = useSequenceMap()
+let map: maplibregl.Map | null = null
+
+const TILE_STYLE = 'https://tiles.openfreemap.org/styles/positron'
+const SOURCE_ID = 'sequence-items'
+const DIRECTION_LAYER_ID = 'sequence-items-direction'
+const LAYER_ID = 'sequence-items-layer'
+const LABEL_LAYER_ID = 'sequence-items-label'
+const MAP_CONTAINER_ID = 'sequence-map-container'
+
+function createDirectionCone(): ImageData {
+  const size = 64
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+  const ctx = canvas.getContext('2d')!
+  // White sector pointing up — SDF tinting handles color
+  ctx.fillStyle = 'white'
+  ctx.beginPath()
+  ctx.moveTo(size / 2, size / 2)
+  ctx.arc(size / 2, size / 2, size / 2 - 2, -Math.PI / 2 - Math.PI / 6, -Math.PI / 2 + Math.PI / 6)
+  ctx.closePath()
+  ctx.fill()
+  return ctx.getImageData(0, 0, size, size)
+}
+
+onMounted(() => {
+  map = new maplibregl.Map({
+    container: MAP_CONTAINER_ID,
+    style: TILE_STYLE,
+    attributionControl: { compact: true },
+  })
+
+  map.on('load', () => {
+    if (!map) return
+
+    map.addImage('direction-cone', createDirectionCone(), { sdf: true })
+    map.addSource(SOURCE_ID, { type: 'geojson', data: geoJSON.value })
+    map.addLayer({
+      id: DIRECTION_LAYER_ID,
+      type: 'symbol',
+      source: SOURCE_ID,
+      minzoom: 16,
+      filter: ['has', 'compass_angle'],
+      layout: {
+        'icon-image': 'direction-cone',
+        'icon-rotate': ['get', 'compass_angle'],
+        'icon-rotation-alignment': 'map',
+        'icon-allow-overlap': true,
+        'icon-ignore-placement': true,
+        'icon-size': 0.6,
+      },
+      paint: {
+        'icon-color': ['case', ['get', 'selected'], '#16a34a', '#94a3b8'],
+        'icon-opacity': 0.8,
+      },
+    })
+    map.addLayer({
+      id: LAYER_ID,
+      type: 'circle',
+      source: SOURCE_ID,
+      paint: {
+        'circle-color': ['case', ['get', 'selected'], '#dcfce7', '#cbd5e1'],
+        'circle-radius': 6,
+        'circle-stroke-width': 1.5,
+        'circle-stroke-color': ['case', ['get', 'selected'], '#16a34a', '#94a3b8'],
+      },
+    })
+
+    map.addLayer({
+      id: LABEL_LAYER_ID,
+      type: 'symbol',
+      source: SOURCE_ID,
+      minzoom: 16,
+      layout: {
+        'text-field': ['get', 'number'],
+        'text-size': 16,
+        'text-offset': [1.25, 0],
+        'text-anchor': 'left',
+        'text-allow-overlap': true,
+        'text-ignore-placement': true,
+      },
+      paint: {
+        'text-color': ['case', ['get', 'selected'], '#16a34a', '#94a3b8'],
+        'text-halo-color': '#ffffff',
+        'text-halo-width': 1.5,
+      },
+    })
+
+    const coords = geoJSON.value.features.map((f) => f.geometry.coordinates as [number, number])
+
+    if (coords.length >= 2) {
+      const lngs = coords.map(([lng]) => lng)
+      const lats = coords.map(([, lat]) => lat)
+      map.fitBounds(
+        [
+          [Math.min(...lngs), Math.min(...lats)],
+          [Math.max(...lngs), Math.max(...lats)],
+        ],
+        { padding: 40, animate: false },
+      )
+    } else if (coords.length === 1) {
+      map.jumpTo({ center: coords[0]!, zoom: 14 })
+    }
+  })
+})
+
+watch(geoJSON, (newGeoJSON) => {
+  if (!map) return
+  const source = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined
+  source?.setData(newGeoJSON)
+})
+
+onUnmounted(() => {
+  map?.remove()
+  map = null
+})
+</script>
+
+<template>
+  <div :id="MAP_CONTAINER_ID" class="map-container max-w-7xl mx-auto w-full" />
+</template>
+
+<style scoped>
+.map-container {
+  width: 100%;
+  height: 300px;
+}
+</style>

--- a/src/composables/__tests__/useSequenceMap.test.ts
+++ b/src/composables/__tests__/useSequenceMap.test.ts
@@ -1,0 +1,119 @@
+import { useSequenceMap } from '@/composables/useSequenceMap'
+import { useCollectionsStore } from '@/stores/collections.store'
+import type { Item } from '@/types/image'
+import { beforeEach, describe, expect, test } from 'bun:test'
+import type { Point } from 'geojson'
+import { createPinia, setActivePinia } from 'pinia'
+
+const makeItem = (
+  overrides: Partial<Item> & {
+    latitude?: number
+    longitude?: number
+    selected?: boolean
+    compass_angle?: number
+  } = {},
+): Item => {
+  const { latitude = 48.8566, longitude = 2.3522, selected = true, compass_angle, ...rest } = overrides
+  return {
+    id: 'item-1',
+    index: 0,
+    isSkeleton: false,
+    meta: {
+      selected,
+      description: { language: 'en', value: '' },
+      categories: '',
+    },
+    image: {
+      id: 'img-1',
+      title: 'test.jpg',
+      description: '',
+      dates: { taken: new Date('2024-01-01') },
+      location: { latitude, longitude, ...(compass_angle !== undefined ? { compass_angle } : {}) },
+      existing: [],
+      urls: { thumb_256: '', thumb_1024: '', original: '' },
+    },
+    ...rest,
+  } as Item
+}
+
+describe('useSequenceMap', () => {
+  let store: ReturnType<typeof useCollectionsStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useCollectionsStore()
+  })
+
+  test('returns FeatureCollection with a feature for each valid item', () => {
+    store.items.a = makeItem({ id: 'a' })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.type).toBe('FeatureCollection')
+    expect(geoJSON.value.features).toHaveLength(1)
+  })
+
+  test('selected item has selected=true property', () => {
+    store.items.a = makeItem({ id: 'a', selected: true })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features[0]!.properties?.selected).toBe(true)
+  })
+
+  test('unselected item has selected=false property', () => {
+    store.items.a = makeItem({ id: 'a', selected: false })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features[0]!.properties?.selected).toBe(false)
+  })
+
+  test('skeleton items are excluded', () => {
+    store.items.skeleton = makeItem({ id: 'skeleton', isSkeleton: true })
+    store.items.real = makeItem({ id: 'real', isSkeleton: false })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features).toHaveLength(1)
+  })
+
+  test('coordinates are in [longitude, latitude] order', () => {
+    store.items.a = makeItem({ id: 'a', latitude: 10, longitude: 20 })
+    const { geoJSON } = useSequenceMap()
+    const coords = (geoJSON.value.features[0]!.geometry as Point).coordinates
+    expect(coords[0]).toBe(20) // longitude first
+    expect(coords[1]).toBe(10) // latitude second
+  })
+
+  test('empty store returns empty FeatureCollection', () => {
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.type).toBe('FeatureCollection')
+    expect(geoJSON.value.features).toHaveLength(0)
+  })
+
+  test('geoJSON updates reactively when store items change', () => {
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features).toHaveLength(0)
+    store.items.a = makeItem({ id: 'a' })
+    expect(geoJSON.value.features).toHaveLength(1)
+  })
+
+  test('includes index as number in properties', () => {
+    store.items.a = makeItem({ id: 'a', index: 3 })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features[0]!.properties?.number).toBe(3)
+  })
+
+  test('includes compass_angle in properties when present', () => {
+    store.items.a = makeItem({ id: 'a', compass_angle: 90 })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features[0]!.properties?.compass_angle).toBe(90)
+  })
+
+  test('omits compass_angle from properties when absent', () => {
+    store.items.a = makeItem({ id: 'a' })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features[0]!.properties?.compass_angle).toBeUndefined()
+  })
+
+  test('geoJSON updates reactively when selection changes', () => {
+    store.items.a = makeItem({ id: 'a', selected: true })
+    const { geoJSON } = useSequenceMap()
+    expect(geoJSON.value.features[0]!.properties?.selected).toBe(true)
+    store.items.a!.meta.selected = false
+    expect(geoJSON.value.features[0]!.properties?.selected).toBe(false)
+  })
+})

--- a/src/composables/useSequenceMap.ts
+++ b/src/composables/useSequenceMap.ts
@@ -1,0 +1,31 @@
+import { useCollectionsStore } from '@/stores/collections.store'
+import type { FeatureCollection, Point } from 'geojson'
+import { computed } from 'vue'
+
+export function useSequenceMap() {
+  const store = useCollectionsStore()
+
+  const geoJSON = computed<
+    FeatureCollection<Point, { selected: boolean; number: number; compass_angle?: number }>
+  >(() => ({
+    type: 'FeatureCollection',
+    features: store.itemsArray
+      .filter((item) => !item.isSkeleton)
+      .map((item) => ({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [item.image.location.longitude, item.image.location.latitude],
+        },
+        properties: {
+          selected: item.meta.selected,
+          number: item.index,
+          ...(item.image.location.compass_angle != null
+            ? { compass_angle: item.image.location.compass_angle }
+            : {}),
+        },
+      })),
+  }))
+
+  return { geoJSON }
+}

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -27,6 +27,7 @@ export type MetadataValue = Metadata[MetadataKey]
 export type Item = {
   image: Image
   meta: Metadata
+  /** 1-based position in the sequence */
   index: number
   id: string
   isSkeleton: boolean


### PR DESCRIPTION
Adds a MapLibre GL map to step 2 (Select) showing all images in the loaded sequence as pins.

## What's new

- **SequenceMap component** — renders a MapLibre GL map (positron style) below the sequence info card, visible only in step 2
- **useSequenceMap composable** — reads `store.itemsArray`, converts to GeoJSON with `selected`, `number`, and `compass_angle` properties; fully unit tested
- **Pin colours** — selected pins use green-100 fill + green-600 stroke (matches row highlight in the list); unselected use slate-200/400
- **Directionality** — SDF wedge icon rotated by `compass_angle`, shown at zoom ≥ 16
- **Image number labels** — 1-based index shown beside each pin at zoom ≥ 16
- **Fit bounds on load** — map jumps to fit all pins with no animation