### PR TITLE
feat: add nth-item selection filter to step 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,18 @@ Real-time features use WebSocket connections defined in AsyncAPI contract (`src/
 - Danger action: `severity="danger"` + `outlined`
 - Primary action: `severity="primary"` (filled, no outlined)
 
+**Button hover overrides in scoped CSS:** PrimeVue injects button CSS at runtime (after static styles) — equal-specificity `:deep()` rules lose. Use `!important` on the properties. This differs from DataTable where PrimeVue uses inline token injection (which `!important` can't beat). Button CSS is class-based, so `!important` works:
+
+```css
+:deep(.my-hover-class:not(:disabled):hover) {
+  background: var(--p-button-primary-background) !important;
+  border-color: var(--p-button-primary-border-color) !important;
+  color: var(--p-button-primary-color) !important;
+}
+```
+
+**PrimeVue CSS variable naming:** `dt('button.primary.background')` → `--p-button-primary-background` (dots to dashes, `--p-` prefix). Verify variable names by reading `node_modules/@primeuix/styles/dist/button/index.mjs`.
+
 ## Domain Concepts
 
 ### Title Template System

--- a/components.d.ts
+++ b/components.d.ts
@@ -54,6 +54,7 @@ declare module 'vue' {
     Image: typeof import('primevue/image')['default']
     IngestPagination: typeof import('./src/components/ui/IngestPagination.vue')['default']
     InputIcon: typeof import('primevue/inputicon')['default']
+    InputNumber: typeof import('primevue/inputnumber')['default']
     InputText: typeof import('primevue/inputtext')['default']
     ItemInputs: typeof import('./src/components/edit/ItemInputs.vue')['default']
     MapillaryCollections: typeof import('./src/components/mapillary/MapillaryCollections.vue')['default']

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     />
     <link rel="preconnect" href="https://rsms.me/">
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-    <title>CuratorBot - Toolforge</title>
+    <title>Curator - Toolforge</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/__tests__/fixtures.ts
+++ b/src/__tests__/fixtures.ts
@@ -1,4 +1,25 @@
 import type { PresetItem } from '@/types/asyncapi'
+import type { Item } from '@/types/image'
+
+export const makeItem = (index: number, selected = false): Item => ({
+  id: `item-${index}`,
+  index,
+  isSkeleton: false,
+  image: {
+    id: `img-${index}`,
+    location: { latitude: 0, longitude: 0, compass_angle: null },
+    thumb_url: '',
+    full_url: '',
+    existing: [],
+    captured_at: '',
+    sequence_id: '',
+  } as unknown as Item['image'],
+  meta: {
+    selected,
+    description: { language: 'en', value: '' },
+    categories: '',
+  },
+})
 
 export const makePreset = (overrides: Partial<PresetItem> = {}): PresetItem => ({
   id: 1,

--- a/src/components/collection/CollectionsControls.vue
+++ b/src/components/collection/CollectionsControls.vue
@@ -3,106 +3,155 @@ const store = useCollectionsStore()
 
 const emit = defineEmits(['select:currentPage'])
 
-const menu = ref()
-const menuItems = computed(() => [
-  {
-    label: 'All images',
-    command: () => store.selectAll(),
-  },
-  {
-    label: 'Current page',
-    command: () => emit('select:currentPage'),
-  },
-  {
-    separator: true,
-  },
-  {
-    label: 'Deselect all',
-    command: () => store.deselectAll(),
-    disabled: store.selectedCount === 0,
-    class: {
-      'bg-red-100': store.selectedCount > 0,
-    },
-  },
-])
+const nthN = ref(2)
+
+const ordinal = (n: number): string => {
+  const mod100 = n % 100
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`
+  const mod10 = n % 10
+  if (mod10 === 1) return `${n}st`
+  if (mod10 === 2) return `${n}nd`
+  if (mod10 === 3) return `${n}rd`
+  return `${n}th`
+}
+
+const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
 </script>
 
 <template>
-  <div class="flex justify-between items-center mt-4 mb-4 gap-4">
-    <div class="flex items-center gap-4 w-auto flex-grow-0 flex-shrink-0">
-      <SimpleMessage
-        severity="info"
-        :closable="false"
-        icon="pi pi-info-circle"
-      >
-        Click on images to select
-      </SimpleMessage>
+  <div class="flex flex-col gap-4">
+    <div class="flex justify-between items-center gap-4">
+      <div class="flex items-center gap-4 w-auto flex-grow-0 flex-shrink-0">
+        <SimpleMessage
+          severity="info"
+          :closable="false"
+          icon="pi pi-info-circle"
+        >
+          Click on images to select
+        </SimpleMessage>
 
-      <span
-        v-tooltip.bottom="
-          store.isBatchLoading ? 'Controls disabled while images are being retrieved' : ''
-        "
-        class="inline-block"
-      >
-        <SelectButton
-          v-model="store.viewMode"
-          :options="[
-            { label: 'List', value: 'list', icon: 'pi pi-list' },
-            { label: 'Grid', value: 'grid', icon: 'pi pi-th-large' },
-          ]"
-          :allowEmpty="false"
-          :disabled="store.isBatchLoading"
-          option-label="label"
-          option-value="value"
-          data-key="value"
-          @update:model-value="store.viewMode = $event"
+        <span
+          v-tooltip.bottom="
+            store.isBatchLoading ? 'Controls disabled while images are being retrieved' : ''
+          "
+          class="inline-block"
         >
-          <template #option="{ option }">
-            <i :class="option.icon" />
-            <span>{{ option.label }}</span>
-          </template>
-        </SelectButton>
-      </span>
+          <SelectButton
+            v-model="store.viewMode"
+            :options="[
+              { label: 'List', value: 'list', icon: 'pi pi-list' },
+              { label: 'Grid', value: 'grid', icon: 'pi pi-th-large' },
+            ]"
+            :allowEmpty="false"
+            :disabled="store.isBatchLoading"
+            option-label="label"
+            option-value="value"
+            data-key="value"
+            @update:model-value="store.viewMode = $event"
+          >
+            <template #option="{ option }">
+              <i :class="option.icon" />
+              <span>{{ option.label }}</span>
+            </template>
+          </SelectButton>
+        </span>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <span class="text-base">
+          <span class="text-green-600 font-medium">{{ store.selectedCount }}</span>
+          selected
+        </span>
+
+        <span
+          class="inline-block"
+          v-tooltip.bottom="
+            store.isBatchLoading ? 'Controls disabled while images are being retrieved' : ''
+          "
+        >
+          <Button
+            severity="primary"
+            :disabled="store.selectedCount === 0 || store.isBatchLoading"
+            @click="store.stepper = '3'"
+            :label="store.selectedCount === 0 ? 'Select items' : 'Start editing'"
+          />
+        </span>
+      </div>
     </div>
-    <div class="flex items-center gap-4">
-      <span class="text-base">
-        <span class="text-green-600 font-medium">{{ store.selectedCount }}</span>
-        selected
-      </span>
-      <Menu
-        ref="menu"
-        :model="menuItems"
-        :popup="true"
-      ></Menu>
-      <span
-        class="inline-block"
-        v-tooltip.bottom="
-          store.isBatchLoading ? 'Controls disabled while images are being retrieved' : ''
-        "
-      >
-        <Button
-          severity="secondary"
-          outlined
-          @click="menu.toggle($event)"
-          :disabled="store.isBatchLoading"
-        >
-          Select
-          <i class="pi pi-chevron-down ml-2"></i>
-        </Button>
-      </span>
-      <span
-        class="inline-block"
-        v-tooltip.bottom="
-          store.isBatchLoading ? 'Controls disabled while images are being retrieved' : ''
-        "
-      >
-        <Button
-          severity="primary"
-          :disabled="store.selectedCount === 0 || store.isBatchLoading"
-          @click="store.stepper = '3'"
-          :label="store.selectedCount === 0 ? 'Select items' : 'Start editing'"
-        />
-      </span>
+
+    <div class="flex items-center gap-3">
+      <span class="text-md text-gray-600">Select</span>
+      <Button
+        class="hover-primary"
+        severity="secondary"
+        outlined
+        label="All images"
+        :disabled="store.isBatchLoading"
+        @click="store.selectAll()"
+      />
+      <Button
+        class="hover-primary"
+        severity="secondary"
+        outlined
+        label="Current page"
+        :disabled="store.isBatchLoading"
+        @click="emit('select:currentPage')"
+      />
+      <Button
+        v-if="store.selectedCount > 0"
+        class="hover-danger-filled"
+        severity="danger"
+        outlined
+        label="Deselect all"
+        :disabled="store.isBatchLoading"
+        @click="store.deselectAll()"
+      />
+    </div>
+
+    <div class="flex items-center gap-3">
+      <span class="text-md text-gray-600">Select every</span>
+      <InputNumber
+        v-model="nthN"
+        :min="2"
+        :max="store.totalImages"
+        :step="1"
+        size="small"
+        show-buttons
+        button-layout="horizontal"
+        increment-button-icon="pi pi-plus"
+        decrement-button-icon="pi pi-minus"
+        :allow-empty="false"
+        :use-grouping="false"
+        input-class="w-20 text-center"
+        :disabled="store.isBatchLoading"
+      />
+      <span class="text-md text-gray-600">-{{ ordinalSuffix(nthN) }} item and</span>
+      <Button
+        class="hover-primary"
+        severity="secondary"
+        outlined
+        label="add them to selection"
+        :disabled="nthN < 2 || store.isBatchLoading"
+        @click="store.selectEveryNth(nthN, true)"
+      />
+      <i
+        class="pi pi-info-circle text-gray-400 cursor-help"
+        v-tooltip.right="`Selects every ${ordinal(nthN)} image in the sequence and adds it to the current selection.`"
+      />
     </div>
   </div>
 </template>
+
+<style scoped>
+:deep(.hover-primary:not(:disabled):hover) {
+  background: var(--p-button-primary-background) !important;
+  border-color: var(--p-button-primary-border-color) !important;
+  color: var(--p-button-primary-color) !important;
+}
+
+:deep(.hover-danger-filled:not(:disabled):hover) {
+  background: var(--p-button-danger-background) !important;
+  border-color: var(--p-button-danger-border-color) !important;
+  color: var(--p-button-danger-color) !important;
+}
+</style>

--- a/src/components/collection/CollectionsControls.vue
+++ b/src/components/collection/CollectionsControls.vue
@@ -3,7 +3,7 @@ const store = useCollectionsStore()
 
 const emit = defineEmits(['select:currentPage'])
 
-const nthN = ref(2)
+const nthN = ref<number | null>(2)
 
 const ordinal = (n: number): string => {
   const mod100 = n % 100
@@ -118,7 +118,6 @@ const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
         :min="2"
         :max="store.totalImages"
         :step="1"
-        :suffix="ordinalSuffix(nthN)"
         size="small"
         show-buttons
         button-layout="horizontal"
@@ -129,18 +128,18 @@ const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
         input-class="w-20 text-center"
         :disabled="store.isBatchLoading"
       />
-      <span class="text-md text-gray-600">item and</span>
+      <span class="text-md text-gray-600">-{{ nthN !== null && nthN >= 2 ? ordinalSuffix(nthN) : '' }} item and</span>
       <Button
         class="hover-primary"
         severity="secondary"
         outlined
         label="add to selection"
-        :disabled="nthN < 2 || store.isBatchLoading"
-        @click="store.selectEveryNth(nthN, true)"
+        :disabled="nthN === null || nthN < 2 || store.isBatchLoading"
+        @click="store.selectEveryNth(nthN!, true)"
       />
       <i
         class="pi pi-info-circle text-gray-400 cursor-help"
-        v-tooltip.right="`Selects every ${ordinal(nthN)} image in the sequence and adds it to the current selection.`"
+        v-tooltip.right="nthN !== null && nthN >= 2 ? `Selects every ${ordinal(nthN)} image in the sequence and adds it to the current selection.` : ''"
       />
     </div>
   </div>

--- a/src/components/collection/CollectionsControls.vue
+++ b/src/components/collection/CollectionsControls.vue
@@ -108,13 +108,17 @@ const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
       />
     </div>
 
-    <div class="flex items-center gap-3">
+    <div
+      v-if="store.totalImages > 1"
+      class="flex items-center gap-3"
+    >
       <span class="text-md text-gray-600">Select every</span>
       <InputNumber
         v-model="nthN"
         :min="2"
         :max="store.totalImages"
         :step="1"
+        :suffix="ordinalSuffix(nthN)"
         size="small"
         show-buttons
         button-layout="horizontal"
@@ -125,12 +129,12 @@ const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
         input-class="w-20 text-center"
         :disabled="store.isBatchLoading"
       />
-      <span class="text-md text-gray-600">-{{ ordinalSuffix(nthN) }} item and</span>
+      <span class="text-md text-gray-600">item and</span>
       <Button
         class="hover-primary"
         severity="secondary"
         outlined
-        label="add them to selection"
+        label="add to selection"
         :disabled="nthN < 2 || store.isBatchLoading"
         @click="store.selectEveryNth(nthN, true)"
       />

--- a/src/components/collection/CollectionsDataView.vue
+++ b/src/components/collection/CollectionsDataView.vue
@@ -168,11 +168,12 @@ watch(
         :rows-per-page-options="rowsPerPageOptions"
         paginator-template="Rows RowsPerPageDropdown FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink CurrentPageReport JumpToPageDropdown"
         current-page-report-template="Page {currentPage} of {totalPages}"
+        :page-link-size="10"
         @page="onPageChange"
         :pt="{
           pcPaginator: {
             root: {
-              class: 'justify-end!',
+              class: store.stepper === '2' ? 'justify-start!' : 'justify-end!',
             },
           },
         }"

--- a/src/stores/__tests__/collections.store.test.ts
+++ b/src/stores/__tests__/collections.store.test.ts
@@ -1,7 +1,58 @@
-import { makePreset } from '@/__tests__/fixtures'
+import { makeItem, makePreset } from '@/__tests__/fixtures'
 import { useCollectionsStore } from '@/stores/collections.store'
 import { beforeEach, describe, expect, it } from 'bun:test'
 import { createPinia, setActivePinia } from 'pinia'
+
+describe('selectEveryNth', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('selects every Nth item by 1-based index when add is false', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({
+      'item-1': makeItem(1),
+      'item-2': makeItem(2),
+      'item-3': makeItem(3),
+      'item-4': makeItem(4),
+      'item-5': makeItem(5),
+      'item-6': makeItem(6),
+    })
+
+    store.selectEveryNth(2, false)
+
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([
+      false, true, false, true, false, true,
+    ])
+  })
+
+  it('clears existing selection before selecting when add is false', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({
+      'item-1': makeItem(1, true),
+      'item-2': makeItem(2, false),
+      'item-3': makeItem(3, false),
+    })
+
+    store.selectEveryNth(3, false)
+
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([false, false, true])
+  })
+
+  it('adds to existing selection when add is true', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({
+      'item-1': makeItem(1, true),
+      'item-2': makeItem(2, false),
+      'item-3': makeItem(3, false),
+      'item-4': makeItem(4, false),
+    })
+
+    store.selectEveryNth(2, true)
+
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([true, true, false, true])
+  })
+})
 
 describe('collections store — preset state', () => {
   beforeEach(() => {

--- a/src/stores/collections.store.ts
+++ b/src/stores/collections.store.ts
@@ -136,6 +136,13 @@ export const useCollectionsStore = defineStore('collections', () => {
     }
   }
 
+  const selectEveryNth = (n: number, add: boolean) => {
+    if (!add) deselectAll()
+    itemsArray.value.forEach((item, i) => {
+      if ((i + 1) % n === 0) item.meta.selected = true
+    })
+  }
+
   const selectPage = (start: number, rows: number) => {
     const end = start + rows
     const pageItems = itemsArray.value.slice(start, end)
@@ -362,6 +369,7 @@ export const useCollectionsStore = defineStore('collections', () => {
     updateSelected,
     selectAll,
     deselectAll,
+    selectEveryNth,
     selectPage,
     setViewMode,
     toggleViewMode,


### PR DESCRIPTION
Adds a new row to the step-2 selection controls that lets users select every Nth image in a sequence and add it to the current selection. Useful when duplicates appear at regular intervals (e.g. every other image is a duplicate).

Also replaces the existing Select dropdown menu with flat inline buttons (All images, Current page, Deselect all) for faster one-click access.

Changes:
- New `selectEveryNth(n, add)` store action with 3 tests
- `CollectionsControls.vue` redesigned with 3 rows: view controls, inline selection buttons, nth-selection row
- Deselect all hidden when nothing is selected
- Pagination left-aligned in step 2
- Hover effects via PrimeVue CSS variables (no JS listeners)

Fixes https://phabricator.wikimedia.org/T423095