### PR TITLE
feat: add traversal-path distance filter for image selection

### DIFF
--- a/src/components/collection/CollectionsControls.vue
+++ b/src/components/collection/CollectionsControls.vue
@@ -14,7 +14,7 @@ const distanceUnit = ref<DistanceUnit>('meters')
 const distanceUnitOptions = DISTANCE_UNITS.map((u) => ({ label: u, value: u }))
 const distanceMethod = ref<'traversal' | 'straight-line'>('traversal')
 const distanceMethodOptions = [
-  { label: 'travesed-path', value: 'traversal' },
+  { label: 'traversed-path', value: 'traversal' },
   { label: 'straight-line', value: 'straight-line' },
 ]
 

--- a/src/components/collection/CollectionsControls.vue
+++ b/src/components/collection/CollectionsControls.vue
@@ -12,6 +12,11 @@ const intervalUnitOptions = INTERVAL_UNITS.map((u) => ({ label: u, value: u }))
 const minDistance = ref<number | null>(100)
 const distanceUnit = ref<DistanceUnit>('meters')
 const distanceUnitOptions = DISTANCE_UNITS.map((u) => ({ label: u, value: u }))
+const distanceMethod = ref<'traversal' | 'straight-line'>('traversal')
+const distanceMethodOptions = [
+  { label: 'travesed-path', value: 'traversal' },
+  { label: 'straight-line', value: 'straight-line' },
+]
 
 const minDistanceInMeters = computed(() => {
   if (minDistance.value === null) return null
@@ -269,7 +274,17 @@ const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
         size="small"
         :disabled="store.isBatchLoading"
       />
-      <span class="text-md text-gray-600">apart (as the crow flies) and</span>
+      <span class="text-md text-gray-600">apart along</span>
+      <SelectButton
+        v-model="distanceMethod"
+        :options="distanceMethodOptions"
+        option-label="label"
+        option-value="value"
+        :allow-empty="false"
+        size="small"
+        :disabled="store.isBatchLoading"
+      />
+      <span class="text-md text-gray-600">and</span>
       <Button
         class="hover-primary"
         severity="secondary"
@@ -278,10 +293,14 @@ const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
         :disabled="minDistanceInMeters === null || store.isBatchLoading"
         v-tooltip.right="
           minDistanceInMeters !== null
-            ? `Clears the current selection, then selects images at least ${minDistance} ${minDistance === 1 ? distanceUnit.replace(/s$/, '') : distanceUnit} apart.`
+            ? `Clears the current selection, then selects images at least ${minDistance} ${minDistance === 1 ? distanceUnit.replace(/s$/, '') : distanceUnit} apart (${distanceMethod === 'traversal' ? 'measured along the path' : 'straight-line'}).`
             : ''
         "
-        @click="store.selectByMinDistance(minDistanceInMeters!, false)"
+        @click="
+          distanceMethod === 'traversal'
+            ? store.selectByTraversalDistance(minDistanceInMeters!, false)
+            : store.selectByMinDistance(minDistanceInMeters!, false)
+        "
       />
       <span class="text-sm text-gray-400">or</span>
       <Button
@@ -292,10 +311,14 @@ const ordinalSuffix = (n: number): string => ordinal(n).slice(-2)
         :disabled="minDistanceInMeters === null || store.isBatchLoading"
         v-tooltip.right="
           minDistanceInMeters !== null
-            ? `Keeps the current selection and also selects images at least ${minDistance} ${minDistance === 1 ? distanceUnit.replace(/s$/, '') : distanceUnit} apart.`
+            ? `Keeps the current selection and also selects images at least ${minDistance} ${minDistance === 1 ? distanceUnit.replace(/s$/, '') : distanceUnit} apart (${distanceMethod === 'traversal' ? 'measured along the path' : 'straight-line'}).`
             : ''
         "
-        @click="store.selectByMinDistance(minDistanceInMeters!, true)"
+        @click="
+          distanceMethod === 'traversal'
+            ? store.selectByTraversalDistance(minDistanceInMeters!, true)
+            : store.selectByMinDistance(minDistanceInMeters!, true)
+        "
       />
     </div>
   </div>

--- a/src/stores/__tests__/collections.store.test.ts
+++ b/src/stores/__tests__/collections.store.test.ts
@@ -236,6 +236,109 @@ describe('selectByMinDistance', () => {
   })
 })
 
+describe('selectByTraversalDistance', () => {
+  // ~111m per 0.001° at equator
+  const pt = (index: number, selected: boolean, lat: number, lon: number) =>
+    makeItem(index, selected, undefined, lat, lon)
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('always selects first item', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({ a: pt(1, false, 0, 0) })
+
+    store.selectByTraversalDistance(100, false)
+
+    expect(store.itemsArray[0]!.meta.selected).toBe(true)
+  })
+
+  it('selects item when traversal distance meets threshold', () => {
+    const store = useCollectionsStore()
+    // a→b = ~55m, a→b + b→c = ~110m >= 100m
+    store.replaceItems({
+      a: pt(1, false, 0, 0),
+      b: pt(2, false, 0, 0.0005),
+      c: pt(3, false, 0, 0.001),
+    })
+
+    store.selectByTraversalDistance(100, false)
+
+    // a: first (selected); b: ~55m accumulated, skip; c: ~110m accumulated, select
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([true, false, true])
+  })
+
+  it('accumulates across skipped points from last selected, not straight-line', () => {
+    const store = useCollectionsStore()
+    // a→b→c path is ~110m traversal; straight-line a→c is ~78m
+    store.replaceItems({
+      a: pt(1, false, 0, 0),
+      b: pt(2, false, 0.0005, 0),
+      c: pt(3, false, 0.0005, 0.0005),
+    })
+
+    store.selectByTraversalDistance(100, false)
+
+    // traversal: a→b ~55m, b→c ~55m, total ~110m → c selected
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([true, false, true])
+  })
+
+  it('resets accumulator after selection', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({
+      a: pt(1, false, 0, 0),
+      b: pt(2, false, 0, 0.001),
+      c: pt(3, false, 0, 0.0015),
+    })
+
+    store.selectByTraversalDistance(100, false)
+
+    // a: selected; b: ~111m from a, select, reset; c: ~55m from b, skip
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([true, true, false])
+  })
+
+  it('clears existing selection when add is false', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({
+      a: pt(1, true, 0, 0),
+      b: pt(2, true, 0, 0.0005),
+      c: pt(3, true, 0, 0.001),
+    })
+
+    store.selectByTraversalDistance(100, false)
+
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([true, false, true])
+  })
+
+  it('keeps pre-selected item that fails threshold when add is true', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({
+      a: pt(1, false, 0, 0),
+      b: pt(2, true, 0, 0.0005),
+    })
+
+    store.selectByTraversalDistance(100, true)
+
+    // b is ~55m traversal from a — fails — but stays selected (add=true never deselects)
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([true, true])
+  })
+
+  it('adds to existing selection when add is true', () => {
+    const store = useCollectionsStore()
+    store.replaceItems({
+      a: pt(1, false, 0, 0),
+      b: pt(2, true, 0, 0.0005),
+      c: pt(3, false, 0, 0.001),
+    })
+
+    store.selectByTraversalDistance(100, true)
+
+    // a: selected; b: ~55m traversal, fails but stays; c: ~110m traversal, select
+    expect(store.itemsArray.map((i) => i.meta.selected)).toEqual([true, true, true])
+  })
+})
+
 describe('collections store — preset state', () => {
   beforeEach(() => {
     setActivePinia(createPinia())

--- a/src/stores/collections.store.ts
+++ b/src/stores/collections.store.ts
@@ -170,6 +170,29 @@ export const useCollectionsStore = defineStore('collections', () => {
     }
   }
 
+  const selectByTraversalDistance = (minMeters: number, add: boolean) => {
+    if (!add) deselectAll()
+    let accumulated = 0
+    let lastLat: number | null = null
+    let lastLon: number | null = null
+    for (const item of chronoItems.value) {
+      const { latitude, longitude } = item.image.location
+      if (lastLat === null || lastLon === null) {
+        item.meta.selected = true
+        lastLat = latitude
+        lastLon = longitude
+      } else {
+        accumulated += haversineDistance(lastLat, lastLon, latitude, longitude)
+        lastLat = latitude
+        lastLon = longitude
+        if (accumulated >= minMeters) {
+          item.meta.selected = true
+          accumulated = 0
+        }
+      }
+    }
+  }
+
   const selectByMinInterval = (minSeconds: number, add: boolean) => {
     if (!add) deselectAll()
     let lastSelectedTime: Date | null = null
@@ -418,6 +441,7 @@ export const useCollectionsStore = defineStore('collections', () => {
     selectEveryNth,
     selectByMinInterval,
     selectByMinDistance,
+    selectByTraversalDistance,
     selectPage,
     setViewMode,
     toggleViewMode,


### PR DESCRIPTION
Adds a traversal-based distance filter alongside the existing straight-line filter. When selecting images by distance, users can now choose between measuring the direct (straight-line) distance from the last selected point, or the cumulative path distance across all intermediate points in the sequence.

The distance row in CollectionsControls combines both methods into a single row with a toggle (defaulting to traversal), so users set one distance threshold and switch method without extra UI clutter.

Fixes https://phabricator.wikimedia.org/T424991