### PR TITLE
feat: update Sequence ID onCollectionImages()

### DIFF
--- a/asyncapi.json
+++ b/asyncapi.json
@@ -862,7 +862,8 @@
         "type": "object",
         "required": [
           "images",
-          "creator"
+          "creator",
+          "sequence_id"
         ],
         "properties": {
           "images": {
@@ -873,6 +874,9 @@
           },
           "creator": {
             "$ref": "#/components/schemas/Creator"
+          },
+          "sequence_id": {
+              "type": "string"
           }
         },
         "additionalProperties": false

--- a/src/composables/useCollections.ts
+++ b/src/composables/useCollections.ts
@@ -166,8 +166,9 @@ export const initCollectionsListeners = () => {
     }
   }
 
-  const onCollectionImages = (creator: Creator, images: Record<string, MediaImage>) => {
+  const onCollectionImages = (creator: Creator, images: Record<string, MediaImage>, sequenceId: string) => {
     store.creator = creator
+    store.input = sequenceId
     const allItems: Record<string, Item> = {}
     let index = 0
     for (const [id, image] of Object.entries(images)) {
@@ -308,7 +309,7 @@ export const initCollectionsListeners = () => {
         onUploadsComplete(msg.data)
         break
       case 'COLLECTION_IMAGES':
-        onCollectionImages(msg.data.creator, msg.data.images)
+        onCollectionImages(msg.data.creator, msg.data.images, msg.data.sequence_id)
         break
       case 'ERROR':
         onError(msg.data)

--- a/src/types/asyncapi.ts
+++ b/src/types/asyncapi.ts
@@ -321,6 +321,7 @@ export type CollectionImages = {
 export type CollectionImagesData = {
   images: Record<string, MediaImage>
   creator: Creator
+  sequence_id: string
 }
 
 export type MediaImage = {


### PR DESCRIPTION
Curator now accepts mapillary URL too instead of letting the user search and input the Sequence ID themselves.

Update the UI to use the processed Sequence ID returned by the backend on the CollectionsInfoCard.

Related: https://github.com/DaxServer/wikibots-curator-backend/pull/251