### PR TITLE
feat: add path line, start/end badges, and map controls to step 2 map

### DIFF
--- a/src/components/collection/SequenceMap.vue
+++ b/src/components/collection/SequenceMap.vue
@@ -2,15 +2,81 @@
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
-const { geoJSON } = useSequenceMap()
+const { geoJSON, pathGeoJSON } = useSequenceMap()
+const store = useCollectionsStore()
 let map: maplibregl.Map | null = null
+let startMarker: maplibregl.Marker | null = null
+let endMarker: maplibregl.Marker | null = null
 
 const TILE_STYLE = 'https://tiles.openfreemap.org/styles/positron'
+const PATH_SOURCE_ID = 'sequence-path'
+const PATH_LAYER_ID = 'sequence-path-layer'
 const SOURCE_ID = 'sequence-items'
 const DIRECTION_LAYER_ID = 'sequence-items-direction'
 const LAYER_ID = 'sequence-items-layer'
 const LABEL_LAYER_ID = 'sequence-items-label'
 const MAP_CONTAINER_ID = 'sequence-map-container'
+
+const showOnlySelected = ref(false)
+
+const displayedGeoJSON = computed(() => ({
+  ...geoJSON.value,
+  features: showOnlySelected.value
+    ? geoJSON.value.features.filter((f) => f.properties?.selected)
+    : geoJSON.value.features,
+}))
+
+watch(
+  () => store.selectedCount,
+  (count) => {
+    if (count === 0) showOnlySelected.value = false
+  },
+)
+
+function createBadgeElement(text: string): HTMLElement {
+  const el = document.createElement('div')
+  el.textContent = text
+  el.style.cssText =
+    'background:#1e40af;color:#ffffff;font-size:11px;font-weight:600;padding:2px 7px;border-radius:4px;white-space:nowrap;pointer-events:none;font-family:sans-serif;line-height:1.4'
+  return el
+}
+
+function updateEndpointMarkers() {
+  startMarker?.remove()
+  endMarker?.remove()
+  startMarker = null
+  endMarker = null
+  if (!map) return
+
+  for (const feature of geoJSON.value.features) {
+    const label = feature.properties?.label
+    if (label !== 'Start' && label !== 'End') continue
+    const [lng, lat] = feature.geometry.coordinates as [number, number]
+    const marker = new maplibregl.Marker({ element: createBadgeElement(label), anchor: 'top', offset: [0, 8] })
+      .setLngLat([lng, lat])
+      .addTo(map)
+    if (label === 'Start') startMarker = marker
+    else endMarker = marker
+  }
+}
+
+function fitAllPoints(animate = false) {
+  if (!map) return
+  const coords = geoJSON.value.features.map((f) => f.geometry.coordinates as [number, number])
+  if (coords.length >= 2) {
+    const lngs = coords.map(([lng]) => lng)
+    const lats = coords.map(([, lat]) => lat)
+    map.fitBounds(
+      [
+        [Math.min(...lngs), Math.min(...lats)],
+        [Math.max(...lngs), Math.max(...lats)],
+      ],
+      { padding: 40, animate },
+    )
+  } else if (coords.length === 1) {
+    map.flyTo({ center: coords[0]!, zoom: 14 })
+  }
+}
 
 function createDirectionCone(): ImageData {
   const size = 64
@@ -38,8 +104,19 @@ onMounted(() => {
   map.on('load', () => {
     if (!map) return
 
+    map.addSource(PATH_SOURCE_ID, { type: 'geojson', data: pathGeoJSON.value })
+    map.addLayer({
+      id: PATH_LAYER_ID,
+      type: 'line',
+      source: PATH_SOURCE_ID,
+      paint: {
+        'line-color': '#94a3b8',
+        'line-width': 2,
+      },
+    })
+
     map.addImage('direction-cone', createDirectionCone(), { sdf: true })
-    map.addSource(SOURCE_ID, { type: 'geojson', data: geoJSON.value })
+    map.addSource(SOURCE_ID, { type: 'geojson', data: displayedGeoJSON.value })
     map.addLayer({
       id: DIRECTION_LAYER_ID,
       type: 'symbol',
@@ -91,46 +168,65 @@ onMounted(() => {
       },
     })
 
-    const coords = geoJSON.value.features.map((f) => f.geometry.coordinates as [number, number])
-
-    if (coords.length >= 2) {
-      const lngs = coords.map(([lng]) => lng)
-      const lats = coords.map(([, lat]) => lat)
-      map.fitBounds(
-        [
-          [Math.min(...lngs), Math.min(...lats)],
-          [Math.max(...lngs), Math.max(...lats)],
-        ],
-        { padding: 40, animate: false },
-      )
-    } else if (coords.length === 1) {
-      map.jumpTo({ center: coords[0]!, zoom: 14 })
-    }
+    updateEndpointMarkers()
+    fitAllPoints(false)
   })
 })
 
-watch(geoJSON, (newGeoJSON) => {
+watch(displayedGeoJSON, (newGeoJSON) => {
   if (!map) return
   const source = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined
   source?.setData(newGeoJSON)
+  updateEndpointMarkers()
+})
+
+watch(pathGeoJSON, (newPathGeoJSON) => {
+  if (!map) return
+  const source = map.getSource(PATH_SOURCE_ID) as maplibregl.GeoJSONSource | undefined
+  source?.setData(newPathGeoJSON)
 })
 
 onUnmounted(() => {
+  startMarker?.remove()
+  endMarker?.remove()
   map?.remove()
   map = null
 })
 </script>
 
 <template>
-  <div
-    :id="MAP_CONTAINER_ID"
-    class="map-container max-w-7xl mx-auto w-full"
-  />
+  <div class="relative max-w-7xl mx-auto w-full">
+    <div
+      :id="MAP_CONTAINER_ID"
+      class="map-container w-full"
+    />
+    <div class="absolute top-2 left-2 z-10 flex gap-2">
+      <SelectButton
+        v-model="showOnlySelected"
+        :options="[
+          { label: 'All', value: false },
+          { label: 'Selected only', value: true },
+        ]"
+        :allow-empty="false"
+        :disabled="store.selectedCount === 0"
+        option-label="label"
+        option-value="value"
+        size="small"
+      />
+      <Button
+        icon="pi pi-expand"
+        size="small"
+        severity="secondary"
+        outlined
+        v-tooltip.right="'Reset view'"
+        @click="fitAllPoints(true)"
+      />
+    </div>
+  </div>
 </template>
 
 <style scoped>
 .map-container {
-  width: 100%;
   height: 300px;
 }
 </style>

--- a/src/composables/__tests__/useSequenceMap.test.ts
+++ b/src/composables/__tests__/useSequenceMap.test.ts
@@ -2,7 +2,7 @@ import { useSequenceMap } from '@/composables/useSequenceMap'
 import { useCollectionsStore } from '@/stores/collections.store'
 import type { Item } from '@/types/image'
 import { beforeEach, describe, expect, test } from 'bun:test'
-import type { Point } from 'geojson'
+import type { LineString, Point } from 'geojson'
 import { createPinia, setActivePinia } from 'pinia'
 
 const makeItem = (
@@ -115,11 +115,94 @@ describe('useSequenceMap', () => {
     expect(geoJSON.value.features[0]!.properties?.compass_angle).toBeUndefined()
   })
 
+  describe('start/end labels', () => {
+    test('first item has label Start', () => {
+      store.items.a = makeItem({ id: 'a', index: 1 })
+      store.items.b = makeItem({ id: 'b', index: 2 })
+      const { geoJSON } = useSequenceMap()
+      const first = geoJSON.value.features.find((f) => f.properties?.number === 1)
+      expect(first?.properties?.label).toBe('Start')
+    })
+
+    test('last item has label End', () => {
+      store.items.a = makeItem({ id: 'a', index: 1 })
+      store.items.b = makeItem({ id: 'b', index: 2 })
+      const { geoJSON } = useSequenceMap()
+      const last = geoJSON.value.features.find((f) => f.properties?.number === 2)
+      expect(last?.properties?.label).toBe('End')
+    })
+
+    test('middle items have empty label', () => {
+      store.items.a = makeItem({ id: 'a', index: 1 })
+      store.items.b = makeItem({ id: 'b', index: 2 })
+      store.items.c = makeItem({ id: 'c', index: 3 })
+      const { geoJSON } = useSequenceMap()
+      const middle = geoJSON.value.features.find((f) => f.properties?.number === 2)
+      expect(middle?.properties?.label).toBe('')
+    })
+
+    test('single item has no label', () => {
+      store.items.a = makeItem({ id: 'a', index: 1 })
+      const { geoJSON } = useSequenceMap()
+      expect(geoJSON.value.features[0]?.properties?.label).toBe('')
+    })
+  })
+
   test('geoJSON updates reactively when selection changes', () => {
     store.items.a = makeItem({ id: 'a', selected: true })
     const { geoJSON } = useSequenceMap()
     expect(geoJSON.value.features[0]!.properties?.selected).toBe(true)
     store.items.a!.meta.selected = false
     expect(geoJSON.value.features[0]!.properties?.selected).toBe(false)
+  })
+
+  describe('pathGeoJSON', () => {
+    test('returns FeatureCollection', () => {
+      const { pathGeoJSON } = useSequenceMap()
+      expect(pathGeoJSON.value.type).toBe('FeatureCollection')
+    })
+
+    test('returns empty features when store is empty', () => {
+      const { pathGeoJSON } = useSequenceMap()
+      expect(pathGeoJSON.value.features).toHaveLength(0)
+    })
+
+    test('returns empty features when only one item', () => {
+      store.items.a = makeItem({ id: 'a', index: 1 })
+      const { pathGeoJSON } = useSequenceMap()
+      expect(pathGeoJSON.value.features).toHaveLength(0)
+    })
+
+    test('returns single LineString feature when two or more items', () => {
+      store.items.a = makeItem({ id: 'a', index: 1, latitude: 10, longitude: 20 })
+      store.items.b = makeItem({ id: 'b', index: 2, latitude: 11, longitude: 21 })
+      const { pathGeoJSON } = useSequenceMap()
+      expect(pathGeoJSON.value.features).toHaveLength(1)
+      expect(pathGeoJSON.value.features[0]!.geometry.type).toBe('LineString')
+    })
+
+    test('coordinates are [longitude, latitude] in index order', () => {
+      store.items.b = makeItem({ id: 'b', index: 2, latitude: 11, longitude: 21 })
+      store.items.a = makeItem({ id: 'a', index: 1, latitude: 10, longitude: 20 })
+      const { pathGeoJSON } = useSequenceMap()
+      const coords = (pathGeoJSON.value.features[0]!.geometry as LineString).coordinates
+      expect(coords[0]).toEqual([20, 10])
+      expect(coords[1]).toEqual([21, 11])
+    })
+
+    test('excludes skeleton items from path', () => {
+      store.items.a = makeItem({ id: 'a', index: 1, isSkeleton: false })
+      store.items.b = makeItem({ id: 'b', index: 2, isSkeleton: true })
+      const { pathGeoJSON } = useSequenceMap()
+      expect(pathGeoJSON.value.features).toHaveLength(0)
+    })
+
+    test('updates reactively when items are added', () => {
+      const { pathGeoJSON } = useSequenceMap()
+      expect(pathGeoJSON.value.features).toHaveLength(0)
+      store.items.a = makeItem({ id: 'a', index: 1 })
+      store.items.b = makeItem({ id: 'b', index: 2 })
+      expect(pathGeoJSON.value.features).toHaveLength(1)
+    })
   })
 })

--- a/src/composables/useSequenceMap.ts
+++ b/src/composables/useSequenceMap.ts
@@ -1,17 +1,25 @@
 import { useCollectionsStore } from '@/stores/collections.store'
-import type { FeatureCollection, Point } from 'geojson'
+import type { FeatureCollection, LineString, Point } from 'geojson'
 import { computed } from 'vue'
 
 export function useSequenceMap() {
   const store = useCollectionsStore()
 
+  const validItems = computed(() =>
+    store.itemsArray.filter((item) => !item.isSkeleton).sort((a, b) => a.index - b.index),
+  )
+
   const geoJSON = computed<
-    FeatureCollection<Point, { selected: boolean; number: number; compass_angle?: number }>
-  >(() => ({
-    type: 'FeatureCollection',
-    features: store.itemsArray
-      .filter((item) => !item.isSkeleton)
-      .map((item) => ({
+    FeatureCollection<
+      Point,
+      { selected: boolean; number: number; label: string; compass_angle?: number }
+    >
+  >(() => {
+    const items = validItems.value
+    const n = items.length
+    return {
+      type: 'FeatureCollection',
+      features: items.map((item, i) => ({
         type: 'Feature',
         geometry: {
           type: 'Point',
@@ -20,12 +28,34 @@ export function useSequenceMap() {
         properties: {
           selected: item.meta.selected,
           number: item.index,
+          label: n >= 2 && i === 0 ? 'Start' : n >= 2 && i === n - 1 ? 'End' : '',
           ...(item.image.location.compass_angle != null
             ? { compass_angle: item.image.location.compass_angle }
             : {}),
         },
       })),
-  }))
+    }
+  })
 
-  return { geoJSON }
+  const pathGeoJSON = computed<FeatureCollection<LineString>>(() => {
+    const coords = validItems.value.map((item) => [
+      item.image.location.longitude,
+      item.image.location.latitude,
+    ])
+    return {
+      type: 'FeatureCollection',
+      features:
+        coords.length >= 2
+          ? [
+              {
+                type: 'Feature',
+                geometry: { type: 'LineString', coordinates: coords },
+                properties: {},
+              },
+            ]
+          : [],
+    }
+  })
+
+  return { geoJSON, pathGeoJSON }
 }


### PR DESCRIPTION
- Adds gray traversal path line connecting all image points in index order
- Adds Start/End HTML marker badges (blue pill, never blends with map labels)
- Adds All/Selected only toggle to filter visible points on the map
- Adds Reset view button to fly back to fit all points
- 11 new tests for pathGeoJSON and start/end label logic in useSequenceMap