### PR TITLE
feat: update input label and placeholder for sequence ID only

### DIFF
--- a/src/components/collection/CollectionsTable.vue
+++ b/src/components/collection/CollectionsTable.vue
@@ -39,8 +39,10 @@ const onStepperUpdate = (next: string) => {
               class="mt-4 mb-4 flex flex-col gap-4"
               v-focustrap
             >
+              <label for="input" class="w-full text-xl font-medium text-gray-700">Mapillary URL / Sequence ID</label>
               <InputText
                 autofocus
+                id="input"
                 v-model="store.input"
                 :placeholder="placeholder"
               />

--- a/src/components/mapillary/MapillaryCollections.vue
+++ b/src/components/mapillary/MapillaryCollections.vue
@@ -9,8 +9,8 @@ onMounted(() => {
 <template>
   <CollectionLayout>
     <CollectionsTable
-      placeholder="Mapillary sequence ID (e.g., tulzukst7vufhdo1e4z60f)"
-      empty-message="Enter a Mapillary sequence ID to view images"
+      placeholder="Mapillary URL (e.g., https://www.mapillary.com/app/?pKey=165706989090864&focus=photo&lat=) or sequence ID (e.g., tulzukst7vufhdo1e4z60f)"
+      empty-message="Enter a Mapillary URL or a sequence ID to view images"
       id-label="Sequence ID"
       alt-prefix="Mapillary image"
     >

--- a/src/composables/__tests__/useCollections.test.ts
+++ b/src/composables/__tests__/useCollections.test.ts
@@ -359,7 +359,7 @@ describe('useCollections Listeners', () => {
         },
       }
 
-      listeners.onCollectionImages(creator, images)
+      listeners.onCollectionImages(creator, images, 'seq1')
 
       expect(store.creator).toEqual(creator)
       expect(store.items.img1).toBeDefined()
@@ -387,7 +387,7 @@ describe('useCollections Listeners', () => {
         },
       }
 
-      listeners.onCollectionImages(creator, images)
+      listeners.onCollectionImages(creator, images, 'seq1')
 
       expect(store.items.img1!.image.dates.taken).toBeInstanceOf(Date)
       expect(store.items.img1!.image.dates.taken.toISOString()).toBe(takenIso)
@@ -399,7 +399,7 @@ describe('useCollections Listeners', () => {
       const creator = { id: 'c1', username: 'u1', profile_url: '' }
       const images: Record<string, MediaImage> = {}
 
-      listeners.onCollectionImages(creator, images)
+      listeners.onCollectionImages(creator, images, 'seq1')
 
       expect(store.creator).toEqual(creator)
       expect(Object.keys(store.items)).toHaveLength(0)


### PR DESCRIPTION
- Add label 'Mapillary URL / Sequence ID' with `for` attribute to step 1 input in CollectionsTable
- Update MapillaryCollections placeholder and empty message to reflect sequence ID only (no URL)
- Fix useCollections tests: pass `sequenceId` as 3rd arg to `onCollectionImages` calls