### PR TITLE
feat: show in the collections UI to the local timezone

### DIFF
--- a/src/components/mapillary/MapillaryCollections.vue
+++ b/src/components/mapillary/MapillaryCollections.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const store = useCollectionsStore()
+const { toLocalTimezoneString } = useCommons()
 
 onMounted(() => {
   store.setHandler(ImageHandler.MAPILLARY)
@@ -22,7 +23,7 @@ onMounted(() => {
           </span>
           <div>
             <strong>Taken:</strong>
-            {{ item.image.dates.taken ? item.image.dates.taken.toLocaleString() : '—' }}
+            {{ item.image.dates.taken ? toLocalTimezoneString(item.image.dates.taken) : '—' }}
           </div>
           <div>
             <strong>ID:</strong>

--- a/src/composables/useCommons.ts
+++ b/src/composables/useCommons.ts
@@ -29,6 +29,12 @@ export const useCommons = () => {
     verifyTitles,
   } = useTitleVerification()
 
+  const toLocalTimezoneString = (date: Date): string => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const nd = date.toLocaleString(undefined, {timeZone: tz, timeZoneName: "short"})
+    return nd
+  }
+
   const applyMetaDefaults = (item: Item, fallbackTitle: string): Metadata => {
     const { meta, image } = item
     const title = meta.title?.trim() || fallbackTitle
@@ -162,5 +168,6 @@ ${categories}
     getTemplateTitle,
     validateTitle,
     verifyTitles,
+    toLocalTimezoneString,
   }
 }


### PR DESCRIPTION
Local timezone as in local to the user not local to where it was taken. Unfortunately instead of showing the specific timezone e.g. CEST it falls back to the offset style e.g. GMT+2