### PR TITLE
feat: remove Flickr handler

### DIFF
--- a/asyncapi.json
+++ b/asyncapi.json
@@ -1239,8 +1239,7 @@
       "ImageHandler": {
         "type": "string",
         "enum": [
-          "mapillary",
-          "flickr"
+          "mapillary"
         ]
       },
       "Label": {

--- a/src/components/views/FailedUploadsView.vue
+++ b/src/components/views/FailedUploadsView.vue
@@ -95,7 +95,6 @@ onMounted(() => {
           :options="[
             { label: 'All handlers', value: null },
             { label: 'Mapillary', value: 'mapillary' },
-            { label: 'Flickr', value: 'flickr' },
           ]"
           option-label="label"
           option-value="value"

--- a/src/composables/useCommons.ts
+++ b/src/composables/useCommons.ts
@@ -31,7 +31,7 @@ export const useCommons = () => {
 
   const toLocalTimezoneString = (date: Date): string => {
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
-    const nd = date.toLocaleString(undefined, {timeZone: tz, timeZoneName: "short"})
+    const nd = date.toLocaleString(undefined, { timeZone: tz, timeZoneName: 'short' })
     return nd
   }
 
@@ -168,6 +168,6 @@ ${categories}
     getTemplateTitle,
     validateTitle,
     verifyTitles,
-	toLocalTimezoneString,
+    toLocalTimezoneString,
   }
 }

--- a/src/types/asyncapi.ts
+++ b/src/types/asyncapi.ts
@@ -90,7 +90,6 @@ export type FetchImages = {
 
 export enum ImageHandler {
   MAPILLARY = 'mapillary',
-  FLICKR = 'flickr',
 }
 
 export type FetchPresets = {


### PR DESCRIPTION
- Remove flickr from ImageHandler enum in asyncapi.json
- Regenerate TypeScript types (FLICKR enum value dropped)
- Remove Flickr option from handler filter in FailedUploadsView